### PR TITLE
Configure GPIO interrupt for falling edge

### DIFF
--- a/components/gpio/gpio.c
+++ b/components/gpio/gpio.c
@@ -60,7 +60,7 @@ void DEV_GPIO_INT(int32_t Pin, gpio_isr_t isr_handler)
 {
     // Zero-initialize the GPIO configuration structure
     gpio_config_t io_conf = {};
-    io_conf.intr_type = GPIO_INTR_POSEDGE;        // Trigger on negative edge (falling edge)
+    io_conf.intr_type = GPIO_INTR_NEGEDGE;        // Trigger on negative edge (falling edge)
     io_conf.mode = GPIO_MODE_INPUT;               // Set pin as input mode
     io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE; // Disable pull-down
     io_conf.pull_up_en = GPIO_PULLUP_ENABLE;      // Enable pull-up resistor


### PR DESCRIPTION
## Summary
- configure DEV_GPIO_INT to trigger on falling edge
- document negative-edge GPIO interrupt behaviour

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5be581388323b0bad4ead5ad1f7d