### PR TITLE
refactor: return esp_err_t from i2c helpers

### DIFF
--- a/components/i2c/i2c.c
+++ b/components/i2c/i2c.c
@@ -69,7 +69,16 @@ void DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Addr)
         .scl_speed_hz = EXAMPLE_I2C_MASTER_FREQUENCY,  // I2C frequency
         .device_address = Addr,                        // Set new device address
     };
-    
+
+    if (*dev_handle) {
+        esp_err_t rm_ret = i2c_master_bus_rm_device(*dev_handle);
+        if (rm_ret != ESP_OK) {
+            ESP_LOGE(TAG, "I2C device removal failed");
+            return;
+        }
+        *dev_handle = NULL;
+    }
+
     // Update the device with the new address
     if (i2c_master_bus_add_device(handle.bus, &i2c_dev_conf, dev_handle) != ESP_OK) {
         ESP_LOGE(TAG, "I2C address modification failed");  // Log error if address modification fails
@@ -85,10 +94,10 @@ void DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Addr)
  * @param Cmd The command byte to send.
  * @param value The value byte to send.
  */
-void DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t value)
+esp_err_t DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t value)
 {
     uint8_t data[2] = {Cmd, value};  // Create an array with command and value
-    ESP_ERROR_CHECK(i2c_master_transmit(dev_handle, data, sizeof(data), 100));  // Send the data to the device
+    return i2c_master_transmit(dev_handle, data, sizeof(data), 100);  // Send the data to the device
 }
 
 /**
@@ -99,11 +108,9 @@ void DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t
  * @param dev_handle The handle to the I2C device.
  * @return The byte read from the device.
  */
-uint8_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle)
+esp_err_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle, uint8_t *value)
 {
-    uint8_t data[1] = {0};  // Create a buffer to store the received byte
-    ESP_ERROR_CHECK(i2c_master_receive(dev_handle, data, 1, 100));  // Read a byte from the device
-    return data[0];  // Return the received byte
+    return i2c_master_receive(dev_handle, value, 1, 100);  // Read a byte from the device
 }
 
 /**
@@ -116,11 +123,15 @@ uint8_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle)
  * @param Cmd The command byte to send.
  * @return The word read from the device (combined two bytes).
  */
-uint16_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd)
+esp_err_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint16_t *value)
 {
     uint8_t data[2] = {Cmd};  // Create an array with the command byte
-    ESP_ERROR_CHECK(i2c_master_transmit_receive(dev_handle, data, 1, data, 2, 100));  // Send command and receive two bytes
-    return data[1] << 8 | data[0];  // Combine the two bytes into a word (16-bit)
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, data, 1, data, 2, 100);  // Send command and receive two bytes
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    *value = data[1] << 8 | data[0];  // Combine the two bytes into a word (16-bit)
+    return ESP_OK;
 }
 
 /**
@@ -132,9 +143,9 @@ uint16_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd)
  * @param pdata Pointer to the data to send.
  * @param len The number of bytes to send.
  */
-void DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t *pdata, uint8_t len)
+esp_err_t DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, const uint8_t *pdata, uint8_t len)
 {
-    ESP_ERROR_CHECK(i2c_master_transmit(dev_handle, pdata, len, 100));  // Transmit the data block
+    return i2c_master_transmit(dev_handle, pdata, len, 100);  // Transmit the data block
 }
 
 /**
@@ -148,7 +159,7 @@ void DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t *pdata, uin
  * @param pdata Pointer to the buffer where received data will be stored.
  * @param len The number of bytes to read.
  */
-void DEV_I2C_Read_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t *pdata, uint8_t len)
+esp_err_t DEV_I2C_Read_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t *pdata, uint8_t len)
 {
-    ESP_ERROR_CHECK(i2c_master_transmit_receive(dev_handle, &Cmd, 1, pdata, len, 100));  // Send command and receive data
+    return i2c_master_transmit_receive(dev_handle, &Cmd, 1, pdata, len, 100);  // Send command and receive data
 }

--- a/components/i2c/i2c.h
+++ b/components/i2c/i2c.h
@@ -17,6 +17,7 @@
 #include <stdio.h>          // Standard input/output library
 #include <string.h>         // String manipulation functions
 #include "driver/i2c_master.h"    // ESP32 I2C master driver library
+#include "esp_err.h"        // ESP-IDF error codes
 #include "esp_log.h"        // ESP32 logging library for debugging
 #include "gpio.h"           // GPIO header for pin configuration
 
@@ -67,7 +68,7 @@ void DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Addr);
  * @param Cmd The command byte to send to the device.
  * @param value The value byte to send to the device.
  */
-void DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t value);
+esp_err_t DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t value);
 
 /**
  * @brief Read a single byte from the I2C device.
@@ -77,7 +78,7 @@ void DEV_I2C_Write_Byte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t
  * @param dev_handle The handle to the I2C device.
  * @return The byte read from the I2C device.
  */
-uint8_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle);
+esp_err_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle, uint8_t *value);
 
 /**
  * @brief Read a word (2 bytes) from the I2C device.
@@ -89,7 +90,7 @@ uint8_t DEV_I2C_Read_Byte(i2c_master_dev_handle_t dev_handle);
  * @param Cmd The command byte to send.
  * @return The 16-bit word read from the device.
  */
-uint16_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd);
+esp_err_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint16_t *value);
 
 /**
  * @brief Write multiple bytes to the I2C device.
@@ -100,7 +101,7 @@ uint16_t DEV_I2C_Read_Word(i2c_master_dev_handle_t dev_handle, uint8_t Cmd);
  * @param pdata A pointer to the data to write.
  * @param len The number of bytes to write.
  */
-void DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t *pdata, uint8_t len);
+esp_err_t DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, const uint8_t *pdata, uint8_t len);
 
 /**
  * @brief Read multiple bytes from the I2C device.
@@ -112,6 +113,6 @@ void DEV_I2C_Write_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t *pdata, uin
  * @param pdata A pointer to the buffer to store the received data.
  * @param len The number of bytes to read.
  */
-void DEV_I2C_Read_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t *pdata, uint8_t len);
+esp_err_t DEV_I2C_Read_Nbyte(i2c_master_dev_handle_t dev_handle, uint8_t Cmd, uint8_t *pdata, uint8_t len);
 
 #endif

--- a/components/io_extension/io_extension.c
+++ b/components/io_extension/io_extension.c
@@ -22,11 +22,11 @@ io_extension_obj_t IO_EXTENSION;  // Define the global IO_EXTENSION object
  * 
  * @param pin An 8-bit value where each bit represents a pin (0 = input, 1 = output).
  */
-void IO_EXTENSION_IO_Mode(uint8_t pin) 
+void IO_EXTENSION_IO_Mode(uint8_t pin)
 {
     uint8_t data[2] = {IO_EXTENSION_Mode, pin}; // Prepare the data to write to the mode register
     // Write the 8-bit value to the IO mode register
-    DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2);
+    ESP_ERROR_CHECK(DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2));
 }
 
 /**
@@ -66,7 +66,7 @@ void IO_EXTENSION_Output(uint8_t pin, uint8_t value)
 
     uint8_t data[2] = {IO_EXTENSION_IO_OUTPUT_ADDR, IO_EXTENSION.Last_io_value}; // Prepare the data to write to the output register
     // Write the 8-bit value to the IO output register
-    DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2);
+    ESP_ERROR_CHECK(DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2));
 }
 
 /**
@@ -83,7 +83,7 @@ uint8_t IO_EXTENSION_Input(uint8_t pin)
     uint8_t value = 0;
 
     // Read the value of the input pins
-    DEV_I2C_Read_Nbyte(IO_EXTENSION.addr, IO_EXTENSION_IO_INPUT_ADDR, &value, 1);
+    ESP_ERROR_CHECK(DEV_I2C_Read_Nbyte(IO_EXTENSION.addr, IO_EXTENSION_IO_INPUT_ADDR, &value, 1));
     // Return the value of the specific pin(s) by masking with the provided bit mask
     return ((value & (1 << pin)) > 0);
 }
@@ -108,7 +108,7 @@ void IO_EXTENSION_Pwm_Output(uint8_t Value)
     // Calculate the duty cycle based on the resolution (12 bits)
     data[1] = Value * 255 / 100;
     // Write the 8-bit value to the PWM output register
-    DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2);
+    ESP_ERROR_CHECK(DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, 2));
 }
 
 /**
@@ -121,5 +121,7 @@ void IO_EXTENSION_Pwm_Output(uint8_t Value)
 uint16_t IO_EXTENSION_Adc_Input()
 {
     // Read the ADC input value from the IO_EXTENSION device
-    return DEV_I2C_Read_Word(IO_EXTENSION.addr, IO_EXTENSION_ADC_ADDR);
+    uint16_t value = 0;
+    ESP_ERROR_CHECK(DEV_I2C_Read_Word(IO_EXTENSION.addr, IO_EXTENSION_ADC_ADDR, &value));
+    return value;
 }


### PR DESCRIPTION
## Summary
- safely remove existing I2C device handle before re-adding
- refactor low-level I2C helpers to return `esp_err_t` instead of halting on error
- propagate new return values through IO extension calls

## Testing
- `idf.py --version` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5eb12b388323882ffde8acc070ea