### PR TITLE
Guard display config macros with default fallbacks

### DIFF
--- a/components/config/config.h
+++ b/components/config/config.h
@@ -1,5 +1,42 @@
 #pragma once
 #include "sdkconfig.h"
+
+#ifndef CONFIG_DISPLAY_WIDTH
+#warning "CONFIG_DISPLAY_WIDTH non défini, valeur 1024 utilisée"
+#define CONFIG_DISPLAY_WIDTH 1024
+#endif
+#define LCD_WIDTH CONFIG_DISPLAY_WIDTH
+
+#ifndef CONFIG_DISPLAY_HEIGHT
+#warning "CONFIG_DISPLAY_HEIGHT non défini, valeur 600 utilisée"
+#define CONFIG_DISPLAY_HEIGHT 600
+#endif
+#define LCD_HEIGHT CONFIG_DISPLAY_HEIGHT
+
+#ifndef CONFIG_DISPLAY_MARGIN_LEFT
+#warning "CONFIG_DISPLAY_MARGIN_LEFT non défini, valeur 120 utilisée"
+#define CONFIG_DISPLAY_MARGIN_LEFT 120
+#endif
+#define LCD_MARGIN_LEFT CONFIG_DISPLAY_MARGIN_LEFT
+
+#ifndef CONFIG_DISPLAY_MARGIN_RIGHT
+#warning "CONFIG_DISPLAY_MARGIN_RIGHT non défini, valeur 120 utilisée"
+#define CONFIG_DISPLAY_MARGIN_RIGHT 120
+#endif
+#define LCD_MARGIN_RIGHT CONFIG_DISPLAY_MARGIN_RIGHT
+
+#ifndef CONFIG_DISPLAY_MARGIN_TOP
+#warning "CONFIG_DISPLAY_MARGIN_TOP non défini, valeur 0 utilisée"
+#define CONFIG_DISPLAY_MARGIN_TOP 0
+#endif
+#define LCD_MARGIN_TOP CONFIG_DISPLAY_MARGIN_TOP
+
+#ifndef CONFIG_DISPLAY_MARGIN_BOTTOM
+#warning "CONFIG_DISPLAY_MARGIN_BOTTOM non défini, valeur 0 utilisée"
+#define CONFIG_DISPLAY_MARGIN_BOTTOM 0
+#endif
+#define LCD_MARGIN_BOTTOM CONFIG_DISPLAY_MARGIN_BOTTOM
+
 #include <stdint.h>
 
 typedef struct {
@@ -10,13 +47,6 @@ typedef struct {
     uint16_t margin_top;
     uint16_t margin_bottom;
 } display_geometry_t;
-
-#define LCD_WIDTH            CONFIG_DISPLAY_WIDTH
-#define LCD_HEIGHT           CONFIG_DISPLAY_HEIGHT
-#define LCD_MARGIN_LEFT      CONFIG_DISPLAY_MARGIN_LEFT
-#define LCD_MARGIN_RIGHT     CONFIG_DISPLAY_MARGIN_RIGHT
-#define LCD_MARGIN_TOP       CONFIG_DISPLAY_MARGIN_TOP
-#define LCD_MARGIN_BOTTOM    CONFIG_DISPLAY_MARGIN_BOTTOM
 
 #if CONFIG_DISPLAY_ORIENTATION_PORTRAIT
 #define LCD_H_RES LCD_HEIGHT


### PR DESCRIPTION
## Summary
- warn when display configuration macros are missing and provide sensible defaults for width, height and margins

## Testing
- `idf.py --version` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6fba4a448323a58c0c37d6b7b4be