### PR TITLE
Align SDMMC bus width configuration under SD card menu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -28,14 +28,14 @@ menu "Display options"
 endmenu
 
 menu "SD card options"
-choice SDMMC_BUS_WIDTH
-    prompt "SDMMC bus width"
-    default SDMMC_BUS_WIDTH_1
-    help
-        Select the data bus width for the SDMMC host.
-config SDMMC_BUS_WIDTH_1
-    bool "1-bit mode"
-config SDMMC_BUS_WIDTH_4
-    bool "4-bit mode"
-endchoice
+    choice SDMMC_BUS_WIDTH
+        prompt "SDMMC bus width"
+        default SDMMC_BUS_WIDTH_1
+        help
+            Select the data bus width for the SDMMC host.
+        config SDMMC_BUS_WIDTH_1
+            bool "1-bit mode"
+        config SDMMC_BUS_WIDTH_4
+            bool "4-bit mode"
+    endchoice
 endmenu


### PR DESCRIPTION
## Summary
- indent the SDMMC bus width choice and config entries under the "SD card options" menu

## Testing
- ⚠️ `idf.py reconfigure` *(command not found: idf.py)*
- ⚠️ `cmake -S . -B build` *(include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ab70a8e258832385813e2ae361b881