### PR TITLE
Specify component dependencies in main

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES config
+    REQUIRES config rgb_lcd_port gui_paint touch sd
     WHOLE_ARCHIVE
     )


### PR DESCRIPTION
## Summary
- include rgb_lcd_port, gui_paint, touch and sd components as requirements for main

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab73dec08083239940ac83f16c490b