### PR TITLE
Add esp_timer requirement to gui_paint component

### DIFF
--- a/components/gui_paint/CMakeLists.txt
+++ b/components/gui_paint/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "gui_bmp.c" "gui_paint.c" 
+idf_component_register(SRCS "gui_bmp.c" "gui_paint.c"
                         INCLUDE_DIRS "."
-                        REQUIRES fonts
+                        REQUIRES fonts esp_timer
                         )


### PR DESCRIPTION
## Summary
- add esp_timer dependency to gui_paint's CMake component registration

## Testing
- `idf.py build` *(fails: command not found: idf.py)*
- `python -m pip install --user esp-idf` *(fails: No matching distribution found for esp-idf)*
- `python -m pip install --user idfpy` *(fails: No matching distribution found for idfpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab747aa1448323bf321fa1d88aaa10