### PR TITLE
Expose config headers to GUI paint component

### DIFF
--- a/components/gui_paint/CMakeLists.txt
+++ b/components/gui_paint/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "gui_bmp.c" "gui_paint.c" "gui_image.c" "gui_jpg.c" "gui_png.c"
                         INCLUDE_DIRS "."
-                        REQUIRES fonts esp_timer jpeg png
+                        REQUIRES fonts esp_timer jpeg png config
                         )


### PR DESCRIPTION
## Summary
- add `config` dependency to GUI paint component so its headers are visible

## Testing
- `idf.py fullclean build` *(fails: idf.py not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac469b190083239aeee2329afb3aeb