### PR TITLE
Add basic .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
-# Ignore build output and SDK configuration
 build/
 sdkconfig
 sdkconfig.old
-# Compiled objects and binaries
-*.o
 *.bin
 *.elf
-# ESP-IDF generated directories
-managed_components/
-dist/
+*.o


### PR DESCRIPTION
## Summary
- simplify repository .gitignore to ignore build outputs and binary files

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac604fab488323867ff9310fff0aca