### PR TITLE
Validate HTTP response and content length in image_fetcher

### DIFF
--- a/components/image_fetcher/image_fetcher.h
+++ b/components/image_fetcher/image_fetcher.h
@@ -3,4 +3,19 @@
 #include <stddef.h>
 
 esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path);
+
+/**
+ * @brief Download an image over HTTP into PSRAM.
+ *
+ * The function allocates a buffer in PSRAM sized according to the
+ * server-provided Content-Length and fills it with the downloaded data.
+ *
+ * @param url  HTTP URL of the image to download
+ * @param data Output pointer receiving the allocated buffer
+ * @param len  Output length of the downloaded data in bytes
+ *
+ * @return ESP_OK on success, or an error code on failure.
+ *
+ * @note The caller is responsible for calling free() on *data when done.
+ */
 esp_err_t image_fetch_http_to_psram(const char *url, uint8_t **data, size_t *len);


### PR DESCRIPTION
## Summary
- Check HTTP status and Content-Length when fetching images to SD card and PSRAM
- Remove incomplete downloads and free buffers on mismatch
- Document responsibility to `free()` PSRAM buffer returned by `image_fetch_http_to_psram`

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ac61df5c508323937b09814d41ed36