### PR TITLE
wifi: include sdkconfig and handle event group allocation

### DIFF
--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -1,4 +1,5 @@
 #include "wifi.h"
+#include "sdkconfig.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
 #include "esp_netif.h"
@@ -42,6 +43,10 @@ esp_err_t wifi_init_sta(uint32_t timeout_ms)
     }
 
     s_wifi_event_group = xEventGroupCreate();
+    if (s_wifi_event_group == NULL) {
+        ESP_LOGE(TAG, "Failed to create event group");
+        return ESP_ERR_NO_MEM;
+    }
 
     esp_event_handler_instance_t instance_any_id;
     esp_event_handler_instance_t instance_got_ip;


### PR DESCRIPTION
## Summary
- include `sdkconfig.h` in wifi component
- validate `xEventGroupCreate` result and handle allocation failure

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install espressif` *(fails: No matching distribution found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac6756841883239d2ec17c21fd66a0