### PR TITLE
fix: correct waveshare LCD function names

### DIFF
--- a/components/rgb_lcd_port/rgb_lcd_port.c
+++ b/components/rgb_lcd_port/rgb_lcd_port.c
@@ -136,7 +136,7 @@ esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init()
  * @param Yend Ending Y coordinate of the display window (exclusive, relative to Ystart).
  * @param Image Pointer to the image data buffer, representing the full LCD resolution.
  */
-void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image)
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image)
 {
     // Ensure Xstart is within valid range, clip Xend to the screen width if necessary
     if (Xstart < 0) Xstart = 0;
@@ -182,7 +182,7 @@ void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xe
  *
  * @param Image Pointer to the image data buffer.
  */
-void wavesahre_rgb_lcd_display(uint8_t *Image)
+void waveshare_rgb_lcd_display(uint8_t *Image)
 {
     // Draw the entire image on the screen
     esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, LCD_H_RES, LCD_V_RES, Image);
@@ -218,7 +218,7 @@ void waveshare_esp32_s3_rgb_lcd_deinit(void)
  * @return
  *    - ESP_OK: Operation successful.
  */
-void wavesahre_rgb_lcd_bl_on()
+void waveshare_rgb_lcd_bl_on()
 {
     waveshare_rgb_lcd_set_brightness(100);
 }
@@ -233,7 +233,7 @@ void wavesahre_rgb_lcd_bl_on()
  * @return
  *    - ESP_OK: Operation successful.
  */
-void wavesahre_rgb_lcd_bl_off()
+void waveshare_rgb_lcd_bl_off()
 {
     waveshare_rgb_lcd_set_brightness(0);
 }

--- a/components/rgb_lcd_port/rgb_lcd_port.h
+++ b/components/rgb_lcd_port/rgb_lcd_port.h
@@ -95,11 +95,11 @@ void waveshare_esp32_s3_rgb_lcd_deinit(void);
 /**
  * @brief Turn on the LCD backlight.
  */
-void wavesahre_rgb_lcd_bl_on();
+void waveshare_rgb_lcd_bl_on();
 /**
  * @brief Turn off the LCD backlight.
  */
-void wavesahre_rgb_lcd_bl_off();
+void waveshare_rgb_lcd_bl_off();
 
 /**
  * @brief Set RGB LCD backlight brightness (0-100%).
@@ -115,14 +115,14 @@ void waveshare_rgb_lcd_set_brightness(uint8_t level);
  * @param Yend Ending Y coordinate of the region.
  * @param Image Pointer to the image data buffer.
  */
-void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image);
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image);
 
 /**
  * @brief Display a full-frame image on the RGB LCD.
  *
  * @param Image Pointer to the image data buffer.
  */
-void wavesahre_rgb_lcd_display(uint8_t *Image);
+void waveshare_rgb_lcd_display(uint8_t *Image);
 
 /**
  * @brief Retrieve pointers to the frame buffers for double buffering.

--- a/main/main.c
+++ b/main/main.c
@@ -83,7 +83,7 @@ static bool init_peripherals(void)
         return false;
     }
 
-    wavesahre_rgb_lcd_bl_on();
+    waveshare_rgb_lcd_bl_on();
     waveshare_rgb_lcd_set_brightness(100);
     battery_init();
 
@@ -121,7 +121,7 @@ void app_main(void)
         UWORD err_x = g_display.width / TEXT_X_DIVISOR;
         UWORD err_y = g_display.height / TEXT_Y1_DIVISOR;
         Paint_DrawString_EN(err_x, err_y, "Échec carte SD !", &Font24, BLACK, WHITE);
-        wavesahre_rgb_lcd_display(BlackImage);
+        waveshare_rgb_lcd_display(BlackImage);
         app_cleanup();
         return;
     }
@@ -147,7 +147,7 @@ void app_main(void)
                         UWORD err_x = g_display.width / TEXT_X_DIVISOR;
                         UWORD err_y = g_display.height / TEXT_Y1_DIVISOR;
                         Paint_DrawString_EN(err_x, err_y, "Échec WiFi...", &Font24, RED, WHITE);
-                        wavesahre_rgb_lcd_display(BlackImage);
+                        waveshare_rgb_lcd_display(BlackImage);
                         vTaskDelay(pdMS_TO_TICKS(1000));
                     }
                 }
@@ -163,11 +163,11 @@ void app_main(void)
                     UWORD nofile_x = g_display.width / TEXT_X_DIVISOR;
                     UWORD nofile_y = (g_display.height / TEXT_Y1_DIVISOR);
                     Paint_DrawString_EN(nofile_x, nofile_y, "Aucune image distante.", &Font24, RED, WHITE);
-                    wavesahre_rgb_lcd_display(BlackImage);
+                    waveshare_rgb_lcd_display(BlackImage);
                     state = APP_STATE_ERROR;
                 } else {
                     draw_navigation_arrows();
-                    wavesahre_rgb_lcd_display(BlackImage);
+                    waveshare_rgb_lcd_display(BlackImage);
                     state = APP_STATE_NAVIGATION;
                 }
             } else {
@@ -191,12 +191,12 @@ void app_main(void)
                 UWORD nofile_x = g_display.width / TEXT_X_DIVISOR;  
                 UWORD nofile_y = (g_display.height / TEXT_Y1_DIVISOR) + 3 * TEXT_LINE_SPACING;  
                 Paint_DrawString_EN(nofile_x, nofile_y, "Aucun fichier BMP dans ce dossier.", &Font24, RED, WHITE);  
-                wavesahre_rgb_lcd_display(BlackImage);  
+                waveshare_rgb_lcd_display(BlackImage);  
                 app_cleanup();  
                 state = APP_STATE_ERROR;  
             } else {  
                 draw_navigation_arrows();  
-                wavesahre_rgb_lcd_display(BlackImage);  
+                waveshare_rgb_lcd_display(BlackImage);  
                 state = APP_STATE_NAVIGATION;  
             }  
             break;  
@@ -212,7 +212,7 @@ void app_main(void)
                 prev_y = 0;
                 selected_dir = NULL;
                 Paint_Clear(WHITE);
-                wavesahre_rgb_lcd_display(BlackImage);
+                waveshare_rgb_lcd_display(BlackImage);
                 state = APP_STATE_SOURCE_SELECTION;
             }
             break;

--- a/main/ui_navigation.c
+++ b/main/ui_navigation.c
@@ -61,7 +61,7 @@ image_source_t draw_source_selection(void)
     draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                        "Distantes", BTN_LABEL_R_OFFSET_X, WHITE);
 
-    wavesahre_rgb_lcd_display(BlackImage);
+    waveshare_rgb_lcd_display(BlackImage);
 
     enum { HIGHLIGHT_NONE, HIGHLIGHT_LEFT, HIGHLIGHT_RIGHT } highlight = HIGHLIGHT_NONE;
     while (1) {
@@ -78,7 +78,7 @@ image_source_t draw_source_selection(void)
                         }
                         draw_folder_button(btnL_x0, btnL_y0, btnL_x1, btnL_y1,
                                            "Locales", BTN_LABEL_L_OFFSET_X, GRAY);
-                        wavesahre_rgb_lcd_display(BlackImage);
+                        waveshare_rgb_lcd_display(BlackImage);
                         highlight = HIGHLIGHT_LEFT;
                     }
                 } else if (tx >= btnR_x0 && tx <= btnR_x1 && ty >= btnR_y0 && ty <= btnR_y1) {
@@ -89,7 +89,7 @@ image_source_t draw_source_selection(void)
                         }
                         draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                                            "Distantes", BTN_LABEL_R_OFFSET_X, GRAY);
-                        wavesahre_rgb_lcd_display(BlackImage);
+                        waveshare_rgb_lcd_display(BlackImage);
                         highlight = HIGHLIGHT_RIGHT;
                     }
                 } else if (highlight != HIGHLIGHT_NONE) {
@@ -100,7 +100,7 @@ image_source_t draw_source_selection(void)
                         draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                                            "Distantes", BTN_LABEL_R_OFFSET_X, WHITE);
                     }
-                    wavesahre_rgb_lcd_display(BlackImage);
+                    waveshare_rgb_lcd_display(BlackImage);
                     highlight = HIGHLIGHT_NONE;
                 }
             } else if (point_data.cnt == 0 && highlight != HIGHLIGHT_NONE) {
@@ -109,7 +109,7 @@ image_source_t draw_source_selection(void)
                                    "Locales", BTN_LABEL_L_OFFSET_X, WHITE);
                 draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                                    "Distantes", BTN_LABEL_R_OFFSET_X, WHITE);
-                wavesahre_rgb_lcd_display(BlackImage);
+                waveshare_rgb_lcd_display(BlackImage);
                 return src;
             }
         }
@@ -142,7 +142,7 @@ const char *draw_folder_selection(void)
     draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                        "Presentation", BTN_LABEL_R_OFFSET_X, WHITE);
 
-    wavesahre_rgb_lcd_display(BlackImage);
+    waveshare_rgb_lcd_display(BlackImage);
 
     const char *selected_dir = NULL;
     enum { HIGHLIGHT_NONE, HIGHLIGHT_LEFT, HIGHLIGHT_RIGHT } highlight = HIGHLIGHT_NONE;
@@ -163,7 +163,7 @@ const char *draw_folder_selection(void)
                         }
                         draw_folder_button(btnL_x0, btnL_y0, btnL_x1, btnL_y1,
                                            "Reptiles", BTN_LABEL_L_OFFSET_X, GRAY);
-                        wavesahre_rgb_lcd_display(BlackImage);
+                        waveshare_rgb_lcd_display(BlackImage);
                         highlight = HIGHLIGHT_LEFT;
                     }
                 } else if (tx >= btnR_x0 && tx <= btnR_x1 && ty >= btnR_y0 && ty <= btnR_y1) {
@@ -174,7 +174,7 @@ const char *draw_folder_selection(void)
                         }
                         draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                                            "Presentation", BTN_LABEL_R_OFFSET_X, GRAY);
-                        wavesahre_rgb_lcd_display(BlackImage);
+                        waveshare_rgb_lcd_display(BlackImage);
                         highlight = HIGHLIGHT_RIGHT;
                     }
                 } else if (highlight != HIGHLIGHT_NONE) {
@@ -185,7 +185,7 @@ const char *draw_folder_selection(void)
                         draw_folder_button(btnR_x0, btnR_y0, btnR_x1, btnR_y1,
                                            "Presentation", BTN_LABEL_R_OFFSET_X, WHITE);
                     }
-                    wavesahre_rgb_lcd_display(BlackImage);
+                    waveshare_rgb_lcd_display(BlackImage);
                     highlight = HIGHLIGHT_NONE;
                 }
             } else if (point_data.cnt == 0 && highlight != HIGHLIGHT_NONE) {
@@ -198,7 +198,7 @@ const char *draw_folder_selection(void)
                                        "Presentation", BTN_LABEL_R_OFFSET_X, WHITE);
                     selected_dir = "Presentation";
                 }
-                wavesahre_rgb_lcd_display(BlackImage);
+                waveshare_rgb_lcd_display(BlackImage);
                 highlight = HIGHLIGHT_NONE;
             }
         }
@@ -208,7 +208,7 @@ const char *draw_folder_selection(void)
     Paint_DrawString_EN(text_x, text_y1, "Dossier choisi :", &Font24, BLACK, WHITE);
     Paint_DrawString_EN(text_x, text_y2, (char *)selected_dir, &Font24, BLACK, WHITE);
     Paint_DrawString_EN(text_x, text_y2 + TEXT_LINE_SPACING, "Touchez la fleche pour demarrer.", &Font24, BLACK, WHITE);
-    wavesahre_rgb_lcd_display(BlackImage);
+    waveshare_rgb_lcd_display(BlackImage);
     return selected_dir;
 }
 
@@ -290,7 +290,7 @@ nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *pr
             draw_right_arrow();
         }
         if (nav_hl != NAV_HL_NONE) {
-            wavesahre_rgb_lcd_display(BlackImage);
+            waveshare_rgb_lcd_display(BlackImage);
         }
         nav_hl = NAV_HL_NONE;
         *prev_x = 0;
@@ -329,7 +329,7 @@ nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *pr
         draw_navigation_arrows();
         draw_filename_bar(bmp_list.items[*idx]);
         draw_left_arrow();
-        wavesahre_rgb_lcd_display(BlackImage);
+        waveshare_rgb_lcd_display(BlackImage);
         nav_hl = NAV_HL_LEFT;
         *prev_x = tx;
         *prev_y = ty;
@@ -354,18 +354,18 @@ nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *pr
         draw_navigation_arrows();
         draw_filename_bar(bmp_list.items[*idx]);
         draw_right_arrow();
-        wavesahre_rgb_lcd_display(BlackImage);
+        waveshare_rgb_lcd_display(BlackImage);
         nav_hl = NAV_HL_RIGHT;
         *prev_x = tx;
         *prev_y = ty;
     } else {
         if (nav_hl == NAV_HL_LEFT) {
             draw_left_arrow();
-            wavesahre_rgb_lcd_display(BlackImage);
+            waveshare_rgb_lcd_display(BlackImage);
             nav_hl = NAV_HL_NONE;
         } else if (nav_hl == NAV_HL_RIGHT) {
             draw_right_arrow();
-            wavesahre_rgb_lcd_display(BlackImage);
+            waveshare_rgb_lcd_display(BlackImage);
             nav_hl = NAV_HL_NONE;
         }
     }


### PR DESCRIPTION
## Summary
- rename wavesahre_rgb_lcd_* functions to waveshare_rgb_lcd_* in driver
- update all waveshare LCD calls in main application

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac691b50c8832397c2c7bc54d2d56f