### PR TITLE
Add LCD VDD enable via IO extension

### DIFF
--- a/components/config/config.h
+++ b/components/config/config.h
@@ -149,6 +149,10 @@
 #define CONFIG_LCD_BK_LIGHT_ON_LEVEL 1
 #endif
 
+#ifndef CONFIG_IOEXT_LCD_VDD_EN
+#define CONFIG_IOEXT_LCD_VDD_EN 6
+#endif
+
 #include <stdint.h>
 
 typedef struct {

--- a/components/io_extension/CMakeLists.txt
+++ b/components/io_extension/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "io_extension.c" 
+idf_component_register(SRCS "io_extension.c"
                         INCLUDE_DIRS "."
-                        REQUIRES driver i2c gpio
+                        REQUIRES driver i2c gpio config
                     )

--- a/components/io_extension/io_extension.c
+++ b/components/io_extension/io_extension.c
@@ -12,6 +12,7 @@
  *
  ******************************************************************************/
 #include "io_extension.h"  // Include IO_EXTENSION driver header for GPIO functions
+#include "config.h"
  
 io_extension_obj_t IO_EXTENSION;  // Define the global IO_EXTENSION object
 
@@ -124,4 +125,9 @@ uint16_t IO_EXTENSION_Adc_Input()
     uint16_t value = 0;
     ESP_ERROR_CHECK(DEV_I2C_Read_Word(IO_EXTENSION.addr, IO_EXTENSION_ADC_ADDR, &value));
     return value;
+}
+
+void io_extension_lcd_vdd_enable(bool en)
+{
+    IO_EXTENSION_Output(CONFIG_IOEXT_LCD_VDD_EN, en ? 1 : 0);
 }

--- a/components/io_extension/io_extension.h
+++ b/components/io_extension/io_extension.h
@@ -18,6 +18,7 @@
  #define __IO_EXTENSION_H
  
  #include "i2c.h"  // Include I2C header for I2C communication functions
+ #include <stdbool.h>
  
  /* 
   * IO EXTENSION GPIO control via I2C - Register and Command Definitions
@@ -62,6 +63,7 @@
  uint8_t IO_EXTENSION_Input(uint8_t pin);   // Read IO pin input state
  void IO_EXTENSION_Pwm_Output(uint8_t Value);
  uint16_t IO_EXTENSION_Adc_Input();
+ void io_extension_lcd_vdd_enable(bool en);
  
  #endif  // __IO_EXTENSION_H
  

--- a/components/rgb_lcd_port/CMakeLists.txt
+++ b/components/rgb_lcd_port/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "rgb_lcd_port.c"
                         INCLUDE_DIRS "."
-                        REQUIRES driver esp_lcd gpio i2c config
+                        REQUIRES driver esp_lcd gpio i2c config io_extension
                         )

--- a/components/rgb_lcd_port/rgb_lcd_port.c
+++ b/components/rgb_lcd_port/rgb_lcd_port.c
@@ -14,6 +14,7 @@
 #include "rgb_lcd_port.h"
 #include "freertos/semphr.h"
 #include "driver/ledc.h"
+#include "io_extension.h"
 #include <string.h>
 
 
@@ -101,6 +102,7 @@ esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init()
     // Log the initialization of the RGB LCD panel
     ESP_LOGI(TAG, "Initialize RGB LCD panel");
 
+    io_extension_lcd_vdd_enable(true);
     // Initialize the RGB LCD panel
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
 


### PR DESCRIPTION
## Summary
- add configurable IO extension pin for LCD VDD enable
- add helper to toggle LCD power via IO extension
- enable LCD VDD before panel initialization

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac72476c9c83239822afb85ca5c68e