### PR TITLE
Add CAN and RS485 navigation modules with simple NEXT/PREV protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ When fetching images over HTTPS the server's root CA certificate must be provide
 * **Bluetooth Low Energy:** BLE 5 stack accessible through `esp_bt.h`; enable via `CONFIG_BT_BLE_ENABLED`.
 
 ### Field Bus Interfaces
-* **CAN (TWAI):** `GPIO20` (TX) and `GPIO19` (RX) routed to the IO‑Extension header for connection to an external CAN transceiver. Configure `CONFIG_TWAI` and use the provided `can.c` driver.
-* **RS485:** UART1 signals are exposed for half‑duplex RS485 with an external differential transceiver. Activate RS485 mode using `CONFIG_UART_RS485_MODE`.
+* **CAN (TWAI):** `GPIO20` (TX) and `GPIO19` (RX) are routed to the IO‑Extension header for connection to an external CAN transceiver. Place a **120 Ω termination resistor** across `CAN_H` and `CAN_L` at each end of the bus and provide the usual bias resistors if the transceiver does not integrate them. Enable via `CONFIG_TWAI`.
+* **RS485:** UART1 uses `GPIO15` (TXD) and `GPIO16` (RXD) for half‑duplex RS485. A **120 Ω differential terminator** and biasing resistors (typically 680 Ω–1 kΩ pull‑up/pull‑down on the A/B pair) are required on the bus. Activate RS485 mode with `CONFIG_UART_RS485_MODE`.
 
 ### Battery Management
 * On‑board single‑cell Li‑ion charger accepts 5 V from USB‑C or an external source and handles charge, protection and fuel gauging.

--- a/components/can_display/CMakeLists.txt
+++ b/components/can_display/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "can_display.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver freertos touch config)

--- a/components/can_display/can_display.c
+++ b/components/can_display/can_display.c
@@ -1,0 +1,71 @@
+#include "can_display.h"
+#include "driver/twai.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "string.h"
+#include "ui_navigation.h"
+#include "touch/gt911.h"
+#include "config.h"
+#include "esp_log.h"
+
+extern QueueHandle_t s_touch_queue;
+extern const display_geometry_t g_display;
+
+#define CAN_DISPLAY_TAG "CAN_DISP"
+#define CAN_TX_PIN GPIO_NUM_20
+#define CAN_RX_PIN GPIO_NUM_19
+
+static void send_nav_touch(bool next)
+{
+    touch_gt911_point_t ev = { .cnt = 1 };
+    if (next) {
+        ev.x[0] = g_display.width - NAV_MARGIN - ARROW_WIDTH / 2;
+        ev.y[0] = NAV_MARGIN + ARROW_HEIGHT / 2;
+    } else {
+        ev.x[0] = NAV_MARGIN + ARROW_WIDTH / 2;
+        ev.y[0] = NAV_MARGIN + ARROW_HEIGHT / 2;
+    }
+    xQueueSend(s_touch_queue, &ev, portMAX_DELAY);
+}
+
+static void can_display_task(void *arg)
+{
+    twai_message_t msg;
+    while (1) {
+        if (twai_receive(&msg, portMAX_DELAY) == ESP_OK) {
+            if (msg.data_length_code >= 4) {
+                if (memcmp(msg.data, "NEXT", 4) == 0) {
+                    send_nav_touch(true);
+                } else if (memcmp(msg.data, "PREV", 4) == 0) {
+                    send_nav_touch(false);
+                }
+            }
+        }
+    }
+}
+
+esp_err_t can_display_init(void)
+{
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(CAN_TX_PIN, CAN_RX_PIN, TWAI_MODE_NORMAL);
+    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_250KBITS();
+    twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+    esp_err_t ret = twai_driver_install(&g_config, &t_config, &f_config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(CAN_DISPLAY_TAG, "Failed to install TWAI driver: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = twai_start();
+    if (ret != ESP_OK) {
+        ESP_LOGE(CAN_DISPLAY_TAG, "Failed to start TWAI: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    if (xTaskCreate(can_display_task, "can_display_task", 2048, NULL, 5, NULL) != pdPASS) {
+        ESP_LOGE(CAN_DISPLAY_TAG, "Failed to create CAN task");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+

--- a/components/can_display/can_display.h
+++ b/components/can_display/can_display.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize TWAI interface for display navigation commands.
+ *
+ * Installs and starts the TWAI driver on GPIO20 (TX) and GPIO19 (RX).
+ * Incoming CAN frames containing the ASCII strings "NEXT" or "PREV"
+ * will generate synthetic touch events to drive the image navigation.
+ *
+ * @return ESP_OK on success, an error code otherwise.
+ */
+esp_err_t can_display_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/components/rs485_display/CMakeLists.txt
+++ b/components/rs485_display/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "rs485_display.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver freertos touch config)

--- a/components/rs485_display/rs485_display.c
+++ b/components/rs485_display/rs485_display.c
@@ -1,0 +1,86 @@
+#include "rs485_display.h"
+#include "driver/uart.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "string.h"
+#include "ui_navigation.h"
+#include "touch/gt911.h"
+#include "config.h"
+#include "esp_log.h"
+
+extern QueueHandle_t s_touch_queue;
+extern const display_geometry_t g_display;
+
+#define RS485_DISPLAY_TAG "RS485_DISP"
+#define RS485_UART UART_NUM_1
+#define RS485_TXD GPIO_NUM_15
+#define RS485_RXD GPIO_NUM_16
+
+static void send_nav_touch(bool next)
+{
+    touch_gt911_point_t ev = { .cnt = 1 };
+    if (next) {
+        ev.x[0] = g_display.width - NAV_MARGIN - ARROW_WIDTH / 2;
+        ev.y[0] = NAV_MARGIN + ARROW_HEIGHT / 2;
+    } else {
+        ev.x[0] = NAV_MARGIN + ARROW_WIDTH / 2;
+        ev.y[0] = NAV_MARGIN + ARROW_HEIGHT / 2;
+    }
+    xQueueSend(s_touch_queue, &ev, portMAX_DELAY);
+}
+
+static void rs485_display_task(void *arg)
+{
+    uint8_t buf[8];
+    while (1) {
+        int len = uart_read_bytes(RS485_UART, buf, sizeof(buf), portMAX_DELAY);
+        if (len >= 4) {
+            if (memcmp(buf, "NEXT", 4) == 0) {
+                send_nav_touch(true);
+            } else if (memcmp(buf, "PREV", 4) == 0) {
+                send_nav_touch(false);
+            }
+        }
+    }
+}
+
+esp_err_t rs485_display_init(void)
+{
+    uart_config_t cfg = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_DEFAULT,
+    };
+
+    esp_err_t ret = uart_param_config(RS485_UART, &cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(RS485_DISPLAY_TAG, "uart_param_config failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = uart_set_pin(RS485_UART, RS485_TXD, RS485_RXD, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if (ret != ESP_OK) {
+        ESP_LOGE(RS485_DISPLAY_TAG, "uart_set_pin failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = uart_driver_install(RS485_UART, 256, 0, 0, NULL, 0);
+    if (ret != ESP_OK) {
+        ESP_LOGE(RS485_DISPLAY_TAG, "uart_driver_install failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = uart_set_mode(RS485_UART, UART_MODE_RS485_HALF_DUPLEX);
+    if (ret != ESP_OK) {
+        ESP_LOGE(RS485_DISPLAY_TAG, "uart_set_mode failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    if (xTaskCreate(rs485_display_task, "rs485_display_task", 2048, NULL, 5, NULL) != pdPASS) {
+        ESP_LOGE(RS485_DISPLAY_TAG, "Failed to create RS485 task");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+

--- a/components/rs485_display/rs485_display.h
+++ b/components/rs485_display/rs485_display.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize UART1 in RS485 half-duplex mode for navigation commands.
+ *
+ * The UART is configured on GPIO15 (TXD) and GPIO16 (RXD).
+ * ASCII frames "NEXT" or "PREV" received over the bus generate
+ * synthetic touch events to control image navigation.
+ *
+ * @return ESP_OK on success, an error code otherwise.
+ */
+esp_err_t rs485_display_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/main/main.c
+++ b/main/main.c
@@ -23,6 +23,8 @@
 #include "wifi.h"
 #include "image_fetcher.h"
 #include "pm.h"
+#include "can_display.h"
+#include "rs485_display.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,6 +91,15 @@ static bool init_peripherals(void)
     waveshare_rgb_lcd_bl_on();
     waveshare_rgb_lcd_set_brightness(100);
     battery_init();
+
+    if (can_display_init() != ESP_OK) {
+        ESP_LOGE(TAG, "Échec d'initialisation du module CAN");
+        return false;
+    }
+    if (rs485_display_init() != ESP_OK) {
+        ESP_LOGE(TAG, "Échec d'initialisation du module RS485");
+        return false;
+    }
 
     UDOUBLE Imagesize = g_display.width * g_display.height * 2;
     BlackImage = (UBYTE *)malloc(Imagesize);


### PR DESCRIPTION
## Summary
- initialize TWAI on GPIO20/19 and parse ASCII "NEXT"/"PREV" frames to emulate touch events
- add UART1 RS485 half-duplex listener on GPIO15/16 with the same protocol
- document CAN/RS485 pins and required termination/biasing resistors

## Testing
- ⚠️ `idf.py build` *(command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac766883148323b4b1bc99208092b8