### PR TITLE
feat: integrate built-in esp_http_server component

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
     SRCS "main.c" "file_manager.c" "ui_navigation.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch sd battery wifi image_fetcher esp_http_server
+    REQUIRES config rgb_lcd_port gui_paint touch sd battery wifi image_fetcher
+    REQUIRES esp_http_server
     WHOLE_ARCHIVE
     )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,7 +1,7 @@
 dependencies:
   idf:
     version: ">=5.1.0"
-  esp_http_server:
-    version: "*"
+  idf::esp_http_server:
+
 
 


### PR DESCRIPTION
## Summary
- depend on ESP-IDF's built-in `esp_http_server` component via `idf::esp_http_server`
- declare `esp_http_server` requirement in the main component CMake registration

## Testing
- `idf.py reconfigure && idf.py build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7db0aadc8323b62786aab827d757