### PR TITLE
Add EMA-filtered battery readings with configurable backlight scaling

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -35,6 +35,16 @@ config DISPLAY_ORIENTATION_PORTRAIT
     bool "Portrait orientation"
 endchoice
 
+config MIN_BRIGHTNESS
+    int "Minimum backlight brightness (%)"
+    default 25
+    range 0 100
+
+config MAX_BRIGHTNESS
+    int "Maximum backlight brightness (%)"
+    default 100
+    range 0 100
+
 config WIFI_SSID
     string "WiFi SSID"
     default ""

--- a/components/battery/battery.c
+++ b/components/battery/battery.c
@@ -1,10 +1,12 @@
 #include "battery.h"
 #include "io_extension.h"
 #include "esp_log.h"
+#include <stdbool.h>
 
 #define BATTERY_ADC_MAX          4095
 #define BATTERY_VOLTAGE_MAX_MV   4200
 #define BATTERY_VOLTAGE_MIN_MV   3300
+#define BATTERY_EMA_ALPHA        0.1f
 
 static const char *TAG = "battery";
 
@@ -18,13 +20,25 @@ uint8_t battery_get_percentage(void)
 {
     uint16_t raw = IO_EXTENSION_Adc_Input();
     uint32_t voltage_mv = (uint32_t)raw * BATTERY_VOLTAGE_MAX_MV / BATTERY_ADC_MAX;
-    if (voltage_mv < BATTERY_VOLTAGE_MIN_MV) {
+
+    static float s_filtered_mv = 0.0f;
+    static bool s_initialized = false;
+    if (!s_initialized) {
+        s_filtered_mv = (float)voltage_mv;
+        s_initialized = true;
+    } else {
+        s_filtered_mv = BATTERY_EMA_ALPHA * (float)voltage_mv +
+                        (1.0f - BATTERY_EMA_ALPHA) * s_filtered_mv;
+    }
+    uint32_t filt_mv = (uint32_t)s_filtered_mv;
+
+    if (filt_mv < BATTERY_VOLTAGE_MIN_MV) {
         return 0;
     }
-    if (voltage_mv > BATTERY_VOLTAGE_MAX_MV) {
-        voltage_mv = BATTERY_VOLTAGE_MAX_MV;
+    if (filt_mv > BATTERY_VOLTAGE_MAX_MV) {
+        filt_mv = BATTERY_VOLTAGE_MAX_MV;
     }
-    uint32_t percent = (voltage_mv - BATTERY_VOLTAGE_MIN_MV) * 100 /
+    uint32_t percent = (filt_mv - BATTERY_VOLTAGE_MIN_MV) * 100 /
                        (BATTERY_VOLTAGE_MAX_MV - BATTERY_VOLTAGE_MIN_MV);
     if (percent > 100) {
         percent = 100;

--- a/components/config/config.h
+++ b/components/config/config.h
@@ -42,6 +42,16 @@
 #endif
 #define INACTIVITY_TIMEOUT_MS CONFIG_INACTIVITY_TIMEOUT_MS
 
+#ifndef CONFIG_MIN_BRIGHTNESS
+#warning "CONFIG_MIN_BRIGHTNESS non défini, valeur 25 utilisée"
+#define CONFIG_MIN_BRIGHTNESS 25
+#endif
+
+#ifndef CONFIG_MAX_BRIGHTNESS
+#warning "CONFIG_MAX_BRIGHTNESS non défini, valeur 100 utilisée"
+#define CONFIG_MAX_BRIGHTNESS 100
+#endif
+
 #ifndef CONFIG_LCD_PIXEL_CLOCK_HZ
 #define CONFIG_LCD_PIXEL_CLOCK_HZ 30000000
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -128,16 +128,8 @@ void pm_update_activity(void)
 static void process_background_tasks(void)
 {
     uint8_t batt = battery_get_percentage();
-    uint8_t level;
-    if (batt > 75) {
-        level = 100;
-    } else if (batt > 50) {
-        level = 75;
-    } else if (batt > 25) {
-        level = 50;
-    } else {
-        level = 25;
-    }
+    uint8_t level = CONFIG_MIN_BRIGHTNESS +
+                    (CONFIG_MAX_BRIGHTNESS - CONFIG_MIN_BRIGHTNESS) * batt / 100;
     waveshare_rgb_lcd_set_brightness(level);
 
     TickType_t now = xTaskGetTickCount();


### PR DESCRIPTION
## Summary
- Smooth battery voltage using exponential moving average
- Scale backlight brightness linearly based on battery level
- Expose MIN/MAX brightness settings in Kconfig

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8259c3b08323bca79c47167ad2bb