### PR TITLE
refactor: declare http server dependency

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,7 +1,4 @@
 dependencies:
   idf:
     version: ">=5.1.0"
-  idf::esp_http_server:
-
-
-
+  esp_http_server: "*"


### PR DESCRIPTION
## Summary
- simplify `idf_component.yml` to declare esp_http_server dependency explicitly

## Testing
- `idf.py reconfigure` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8581e3cc8323ab6d96c5b5ffaa5d