### PR TITLE
Add nvs_flash dependency to config component

### DIFF
--- a/components/config/CMakeLists.txt
+++ b/components/config/CMakeLists.txt
@@ -1,1 +1,5 @@
-idf_component_register(SRCS "display.c" INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS "display.c"
+    INCLUDE_DIRS "."
+    REQUIRES nvs_flash
+)


### PR DESCRIPTION
## Summary
- declare `nvs_flash` as a dependency for the config component

## Testing
- ⚠️ `idf.py fullclean build` *(command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90d986488323bd1188be2693373c