### PR TITLE
wifi: add nvs_flash and provisioning deps

### DIFF
--- a/components/wifi/CMakeLists.txt
+++ b/components/wifi/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "wifi.c"
     INCLUDE_DIRS "."
-    REQUIRES esp_wifi esp_event esp_netif
+    REQUIRES esp_wifi esp_event esp_netif nvs_flash wifi_provisioning
 )


### PR DESCRIPTION
## Summary
- ensure Wi-Fi component depends on NVS and provisioning

## Testing
- `idf.py fullclean` *(fails: command not found: idf.py)*
- `idf.py build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92e4ad6883238dbed32a2018a0ad