### PR TITLE
Fix missing esp_mac include for MAC API

### DIFF
--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -15,6 +15,7 @@
 #endif
 #include "esp_system.h"
 #include "esp_timer.h"
+#include "esp_mac.h"
 #include <stdio.h>
 
 static const char *TAG = "wifi";


### PR DESCRIPTION
## Summary
- include `esp_mac.h` so esp_read_mac is available

## Testing
- `idf.py build` *(fails: command not found)*
- `/tmp/esp-idf/install.sh` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac98eb414083239509e912eafd6bfa