### PR TITLE
Define default Wi-Fi provisioning timeout

### DIFF
--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -18,6 +18,10 @@
 #include "esp_mac.h"
 #include <stdio.h>
 
+#ifndef CONFIG_WIFI_PROV_TIMEOUT_MS
+#define CONFIG_WIFI_PROV_TIMEOUT_MS 60000
+#endif
+
 static const char *TAG = "wifi";
 
 static EventGroupHandle_t s_wifi_event_group;


### PR DESCRIPTION
## Summary
- Ensure Wi-Fi provisioning timeout has a default of 60 seconds if not set in configuration

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake .` *(fails: cannot find /tools/cmake/project.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_68ac99c769248323bad686fa201fa0f4