### PR TITLE
feat: add esp_lcd_touch dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "main.c" "file_manager.c" "ui_navigation.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch sd battery wifi image_fetcher esp_http_server
+    REQUIRES config rgb_lcd_port gui_paint touch sd battery wifi image_fetcher esp_http_server esp_lcd_touch
     WHOLE_ARCHIVE
     )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,3 +1,6 @@
 dependencies:
-  idf:
-    version: ">=5.1.0"
+  idf: { version: ">=5.1.0" }
+  esp_lcd_touch:
+    version: "*"
+    source: idf
+


### PR DESCRIPTION
## Summary
- add `esp_lcd_touch` to component requirements
- declare `esp_lcd_touch` dependency in component manifest

## Testing
- `idf.py fullclean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f604a8883239cd3cbe25a42a9b4