### PR TITLE
chore: update touch dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,6 @@
 idf_component_register(
     SRCS "main.c" "file_manager.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server
+    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server esp_lcd_touch
     WHOLE_ARCHIVE
     )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,3 @@
 dependencies:
   idf: { version: ">=5.1.0" }
-  esp_lcd_touch:
-    version: "*"
-    source: idf
 


### PR DESCRIPTION
## Summary
- drop esp_lcd_touch from component dependency list
- require esp_lcd_touch at build time

## Testing
- `idf.py reconfigure build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aca8168cec8323880fd6501ebee77d