### PR TITLE
fix: manage esp_lcd_touch dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,6 @@
 idf_component_register(
     SRCS "main.c" "file_manager.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server esp_lcd_touch
+    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server
     WHOLE_ARCHIVE
     )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,3 +1,4 @@
 dependencies:
   idf: { version: ">=5.1.0" }
+  espressif/esp_lcd_touch: "*"
 


### PR DESCRIPTION
## Summary
- remove `esp_lcd_touch` from CMake `REQUIRES`
- add `espressif/esp_lcd_touch` dependency in `idf_component.yml`

## Testing
- `idf.py reconfigure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acab67f4fc832388e43056518401c1