### PR TITLE
feat: add battery dependency to ui_navigation

### DIFF
--- a/components/ui_navigation/CMakeLists.txt
+++ b/components/ui_navigation/CMakeLists.txt
@@ -1,3 +1,6 @@
-idf_component_register(SRCS "ui_navigation.c"
-                       INCLUDE_DIRS "."
-                       REQUIRES config gui_paint touch)
+idf_component_register(
+    SRCS "ui_navigation.c"
+    INCLUDE_DIRS "."
+    REQUIRES config gui_paint touch
+    PRIV_REQUIRES battery
+)


### PR DESCRIPTION
## Summary
- include battery component as private dependency for ui_navigation

## Testing
- `idf.py build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68acb020d7288323a2abf5ff1a147f39