### PR TITLE
Add main component dependency for ui_navigation

### DIFF
--- a/components/ui_navigation/CMakeLists.txt
+++ b/components/ui_navigation/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "ui_navigation.c"
     INCLUDE_DIRS "."
     REQUIRES config gui_paint touch
-    PRIV_REQUIRES battery
+    PRIV_REQUIRES battery main
 )


### PR DESCRIPTION
## Summary
- ensure ui_navigation depends on main component

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb197ae348323aa9b1a9b07bb0736