### PR TITLE
Include GT911 header in touch task

### DIFF
--- a/main/touch_task.h
+++ b/main/touch_task.h
@@ -6,6 +6,7 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "touch.h"
+#include "touch/gt911.h"
 
 extern TaskHandle_t s_touch_task_handle;
 extern QueueHandle_t s_touch_queue;


### PR DESCRIPTION
## Summary
- expose GT911 touch types to consumers of touch_task by including `touch/gt911.h`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb462bd00832380620f5ecfc3d606