### PR TITLE
Add display component dependencies

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,6 @@
 idf_component_register(
     SRCS "main.c" "file_manager.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server
+    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server can_display rs485_display
     WHOLE_ARCHIVE
     )


### PR DESCRIPTION
## Summary
- include can_display and rs485_display in the main component's dependency list

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68acb5c3c0cc8323af7a9f9b63e4ce80