### PR TITLE
Fix GT911 include path and ensure touch dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,18 @@
-
 idf_component_register(
     SRCS "main.c" "file_manager.c" "touch_task.c" "http_server.c"
     INCLUDE_DIRS "."
-    REQUIRES config rgb_lcd_port gui_paint touch ui_navigation sd battery wifi image_fetcher esp_http_server can_display rs485_display
+    REQUIRES
+        config
+        rgb_lcd_port
+        gui_paint
+        touch
+        ui_navigation
+        sd
+        battery
+        wifi
+        image_fetcher
+        esp_http_server
+        can_display
+        rs485_display
     WHOLE_ARCHIVE
     )

--- a/main/touch_task.h
+++ b/main/touch_task.h
@@ -6,7 +6,7 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "touch.h"
-#include "touch/gt911.h"
+#include "gt911.h"
 
 extern TaskHandle_t s_touch_task_handle;
 extern QueueHandle_t s_touch_queue;


### PR DESCRIPTION
## Summary
- include GT911 header without touch/ prefix
- declare touch component dependency for main build

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb9720d7883239ff431f77948e804