### PR TITLE
Add include guard for GT911 touch header

### DIFF
--- a/components/touch/gt911.h
+++ b/components/touch/gt911.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
+
 /**
  * @file
  * @brief ESP LCD touch: GT911


### PR DESCRIPTION
## Summary
- add `#pragma once` to GT911 touch controller header to avoid multiple inclusion conflicts

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake -S . -B build` *(fails: missing project.cmake from ESP-IDF)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd19fe8c8323a8f345d86b19bf7f