### PR TITLE
fix: adjust GT911 header path

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -7,7 +7,7 @@
 #include "config.h"
 #include "rgb_lcd_port.h"
 #include "sd.h"
-#include "touch/gt911.h"
+#include "gt911.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "esp_log.h"


### PR DESCRIPTION
## Summary
- update GT911 include path for ui navigation

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68acc073f54c83238e293b14665c6083