### PR TITLE
Enable wildcard URI matching for upload paths

### DIFF
--- a/main/http_server.c
+++ b/main/http_server.c
@@ -127,6 +127,7 @@ esp_err_t start_file_server(void)
         return ESP_OK;
     }
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    config.uri_match_fn = httpd_uri_match_wildcard;
     if (httpd_start(&s_server, &config) != ESP_OK) {
         ESP_LOGE(TAG, "httpd_start failed");
         s_server = NULL;


### PR DESCRIPTION
## Summary
- configure HTTP server to use wildcard URI matching so `/upload/<file>` requests are routed correctly

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accdf4b83c8323a3037ede3bd03cdc