### PR TITLE
Restrict uploads to BMP images only

### DIFF
--- a/main/http_server.c
+++ b/main/http_server.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <ctype.h>
 
@@ -75,6 +76,12 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     sanitize_filename(clean_name, filename, sizeof(clean_name));
     if (strlen(clean_name) == 0) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid filename");
+        return ESP_FAIL;
+    }
+
+    size_t n = strlen(clean_name);
+    if (n < 4 || strcasecmp(&clean_name[n-4], ".bmp") != 0) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Only .bmp allowed");
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
## Summary
- Ensure uploaded file names end with `.bmp`
- Include `<strings.h>` for case-insensitive extension comparisons

## Testing
- `idf.py build` *(fails: command not found)*
- `/tmp/test_extension file.txt`
- `/tmp/test_extension image.bmp`


------
https://chatgpt.com/codex/tasks/task_e_68accf38b7008323a483f320780ee6ab