### PR TITLE
Support paginated BMP listing

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -456,7 +456,7 @@ nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *pr
         if (*idx < 0) {
             if (bmp_page_start > 0) {
                 size_t new_start = (bmp_page_start >= bmp_last_page_size) ? bmp_page_start - bmp_last_page_size : 0;
-                if (list_files_sorted(g_base_path, new_start) == ESP_OK && bmp_list.size > 0) {
+                if (list_files_sorted(g_base_path, new_start, BMP_LIST_INIT_CAP) == ESP_OK && bmp_list.size > 0) {
                     *idx = bmp_list.size - 1;
                 } else {
                     *idx = 0;
@@ -480,8 +480,7 @@ nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *pr
         (*idx)++;
         if (*idx >= bmp_list.size) {
             if (bmp_has_more) {
-                size_t new_start = bmp_page_start + bmp_list.size;
-                if (list_files_sorted(g_base_path, new_start) == ESP_OK && bmp_list.size > 0) {
+                if (file_manager_next_page(BMP_LIST_INIT_CAP) == ESP_OK && bmp_list.size > 0) {
                     *idx = 0;
                 } else {
                     *idx = bmp_list.size ? bmp_list.size - 1 : 0;

--- a/main/file_manager.h
+++ b/main/file_manager.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <dirent.h>
 #include "esp_err.h"
 
 #ifdef __cplusplus
@@ -19,9 +20,13 @@ extern bmp_list_t bmp_list;
 extern size_t bmp_page_start;
 extern bool bmp_has_more;
 extern size_t bmp_last_page_size;
+extern DIR *bmp_dir;
+
+#define BMP_LIST_INIT_CAP 16
 
 void bmp_list_free(void);
-esp_err_t list_files_sorted(const char *base_path, size_t start_idx);
+esp_err_t list_files_sorted(const char *base_path, size_t start_idx, size_t max_files);
+esp_err_t file_manager_next_page(size_t max_files);
 
 #ifdef __cplusplus
 }

--- a/main/main.c
+++ b/main/main.c
@@ -227,7 +227,7 @@ void app_main(void)
                 image_fetch_http_to_sd(CONFIG_IMAGE_FETCH_URL, MOUNT_POINT "/remote.bmp");
                 snprintf(g_base_path, sizeof(g_base_path), "%s", MOUNT_POINT);
                 bmp_page_start = 0;
-                esp_err_t err = list_files_sorted(g_base_path, bmp_page_start);
+                esp_err_t err = list_files_sorted(g_base_path, bmp_page_start, BMP_LIST_INIT_CAP);
                 if (err != ESP_OK || bmp_list.size == 0) {
                     UWORD nofile_x = g_display.width / TEXT_X_DIVISOR;
                     UWORD nofile_y = (g_display.height / TEXT_Y1_DIVISOR);
@@ -279,7 +279,7 @@ void app_main(void)
             }
             snprintf(g_base_path, sizeof(g_base_path), "%s/%s", MOUNT_POINT, selected_dir);
             bmp_page_start = 0;
-            esp_err_t err = list_files_sorted(g_base_path, bmp_page_start);
+            esp_err_t err = list_files_sorted(g_base_path, bmp_page_start, BMP_LIST_INIT_CAP);
             if (err != ESP_OK) {
                 ESP_LOGE(TAG, "Erreur lors du listage : %s", esp_err_to_name(err));
             }


### PR DESCRIPTION
## Summary
- stream BMP files from directories without loading all names
- add pagination via `file_manager_next_page`
- expose `DIR*` and page limit in file manager API

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acde78cf688323b328f91734d45b21