### PR TITLE
Enforce TLS and add integrity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ The connection between ESP Board and the LCD is as follows:
    | `CONFIG_UART_ISR_IN_IRAM` & `CONFIG_UART_RS485_MODE` | Allow deterministic RS485 on UART1 | `y` when using RS485 |
    | `CONFIG_PM_ENABLE` | Dynamic power management for battery operation | `y` |
    | `CONFIG_LCD_BACKLIGHT_PWM` | Backlight dimming via PWM | `y` |
-   | `CONFIG_IMAGE_FETCH_INSECURE` | Skip TLS validation for image fetcher | `n` (enable only for testing) |
 
 ### Build and Flash
 
@@ -113,7 +112,11 @@ Refer to the [ESP‑IDF Getting Started Guide](https://docs.espressif.com/projec
 
 ### Certificate requirements
 
-When fetching images over HTTPS the server's root CA certificate must be provided at build time in `components/image_fetcher/cert/cert.pem`. Replace the placeholder file with the PEM‑encoded certificate of your server. Alternatively, enable `CONFIG_IMAGE_FETCH_INSECURE` to bypass validation (not recommended for production).
+When fetching images over HTTPS the server's root CA certificate must be provided at build time in `components/image_fetcher/cert/cert.pem`. Replace the placeholder file with the PEM‑encoded certificate of your server.
+
+### Image integrity
+
+The HTTP server must supply an `X-File-SHA256` header containing the hex-encoded SHA‑256 hash of the payload. The firmware streams the download, reading until the server closes the connection, and rejects the file if the checksum does not match.
 
 ## Hardware Options
 

--- a/components/image_fetcher/CMakeLists.txt
+++ b/components/image_fetcher/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "image_fetcher.c"
     INCLUDE_DIRS "."
-    REQUIRES esp_http_client esp_wifi esp_event esp_netif
+    REQUIRES esp_http_client esp_wifi esp_event esp_netif mbedtls
     EMBED_TXTFILES "cert/cert.pem"
 )

--- a/components/image_fetcher/image_fetcher.c
+++ b/components/image_fetcher/image_fetcher.c
@@ -4,32 +4,36 @@
 #include "esp_heap_caps.h"
 #include "sdkconfig.h"
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "mbedtls/sha256.h"
 
 static const char *TAG = "image_fetcher";
 
-#if !CONFIG_IMAGE_FETCH_INSECURE
 extern const char cert_pem_start[] asm("_binary_cert_pem_start");
-#endif
+
+#define SHA256_HEADER "X-File-SHA256"
 
 #ifndef ESP_ERR_HTTP_STATUS
 #define ESP_ERR_HTTP_STATUS (ESP_ERR_HTTP_BASE + 0x0F)
+#endif
+#ifndef ESP_ERR_HTTP_FETCH_HEADER
+#define ESP_ERR_HTTP_FETCH_HEADER (ESP_ERR_HTTP_BASE + 0x07)
 #endif
 
 esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
 {
     esp_http_client_config_t cfg = {
         .url = url,
-#if CONFIG_IMAGE_FETCH_INSECURE
-        .cert_pem = NULL,
-        .skip_cert_common_name_check = true,
-#else
         .cert_pem = cert_pem_start,
-#endif
+        .keep_alive_enable = true,
     };
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
     if (client == NULL) {
         return ESP_FAIL;
     }
+    esp_http_client_set_header(client, "Connection", "keep-alive");
+    esp_http_client_set_keep_alive(client, true);
     esp_err_t err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "HTTP open failed: %s", esp_err_to_name(err));
@@ -37,19 +41,47 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
         return err;
     }
 
-    int content_length = esp_http_client_fetch_headers(client);
-    if (content_length < 0) {
-        err = content_length;
+    err = esp_http_client_fetch_headers(client);
+    if (err != ESP_OK && err != ESP_ERR_HTTP_FETCH_HEADER) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         return err;
     }
+    int content_length = esp_http_client_get_content_length(client);
     int status = esp_http_client_get_status_code(client);
     if (status != 200) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         return ESP_ERR_HTTP_STATUS;
     }
+
+    const char *hash_hex = esp_http_client_get_header(client, SHA256_HEADER);
+    if (!hash_hex) {
+        esp_http_client_close(client);
+        esp_http_client_cleanup(client);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    uint8_t expected_hash[32];
+    if (strlen(hash_hex) != 64) {
+        esp_http_client_close(client);
+        esp_http_client_cleanup(client);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    for (int i = 0; i < 32; ++i) {
+        char tmp[3] = { hash_hex[2*i], hash_hex[2*i+1], 0 };
+        char *end;
+        long v = strtol(tmp, &end, 16);
+        if (*end != 0 || v < 0 || v > 0xFF) {
+            esp_http_client_close(client);
+            esp_http_client_cleanup(client);
+            return ESP_ERR_INVALID_RESPONSE;
+        }
+        expected_hash[i] = (uint8_t)v;
+    }
+
+    mbedtls_sha256_context sha_ctx;
+    mbedtls_sha256_init(&sha_ctx);
+    mbedtls_sha256_starts(&sha_ctx, 0);
 
     FILE *f = fopen(dest_path, "wb");
     if (!f) {
@@ -60,25 +92,33 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
     uint8_t buf[512];
     int data_read;
     int total_read = 0;
-    while (total_read < content_length) {
+    err = ESP_OK;
+    while (1) {
         data_read = esp_http_client_read(client, (char *)buf, sizeof(buf));
         if (data_read < 0) {
             err = data_read;
             break;
         } else if (data_read == 0) {
-            err = ESP_ERR_HTTP_EAGAIN;
             break;
         }
         fwrite(buf, 1, data_read, f);
         total_read += data_read;
+        mbedtls_sha256_update(&sha_ctx, buf, data_read);
     }
     fclose(f);
+    uint8_t actual_hash[32];
+    mbedtls_sha256_finish(&sha_ctx, actual_hash);
+    mbedtls_sha256_free(&sha_ctx);
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
 
-    if (err != ESP_OK || total_read != content_length) {
+    if (err != ESP_OK || (content_length >= 0 && total_read != content_length)) {
         remove(dest_path);
         return (err != ESP_OK) ? err : ESP_ERR_HTTP_WRITE_DATA;
+    }
+    if (memcmp(actual_hash, expected_hash, sizeof(expected_hash)) != 0) {
+        remove(dest_path);
+        return ESP_ERR_INVALID_RESPONSE;
     }
 
     ESP_LOGI(TAG, "Downloaded %s to %s", url, dest_path);
@@ -91,63 +131,103 @@ esp_err_t image_fetch_http_to_psram(const char *url, uint8_t **data, size_t *len
     *len = 0;
     esp_http_client_config_t cfg = {
         .url = url,
-#if CONFIG_IMAGE_FETCH_INSECURE
-        .cert_pem = NULL,
-        .skip_cert_common_name_check = true,
-#else
         .cert_pem = cert_pem_start,
-#endif
+        .keep_alive_enable = true,
     };
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
     if (client == NULL) {
         return ESP_FAIL;
     }
+    esp_http_client_set_header(client, "Connection", "keep-alive");
+    esp_http_client_set_keep_alive(client, true);
     esp_err_t err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "HTTP open failed: %s", esp_err_to_name(err));
         esp_http_client_cleanup(client);
         return err;
     }
-    int content_length = esp_http_client_fetch_headers(client);
-    if (content_length < 0) {
-        err = content_length;
+    err = esp_http_client_fetch_headers(client);
+    if (err != ESP_OK && err != ESP_ERR_HTTP_FETCH_HEADER) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         return err;
     }
+    int content_length = esp_http_client_get_content_length(client);
     int status = esp_http_client_get_status_code(client);
     if (status != 200) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         return ESP_ERR_HTTP_STATUS;
     }
-    uint8_t *buf = heap_caps_malloc(content_length, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (!buf) {
+
+    const char *hash_hex = esp_http_client_get_header(client, SHA256_HEADER);
+    if (!hash_hex || strlen(hash_hex) != 64) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return ESP_ERR_NO_MEM;
+        return ESP_ERR_INVALID_RESPONSE;
     }
-    int read = 0;
+    uint8_t expected_hash[32];
+    for (int i = 0; i < 32; ++i) {
+        char tmp[3] = { hash_hex[2*i], hash_hex[2*i+1], 0 };
+        char *end;
+        long v = strtol(tmp, &end, 16);
+        if (*end != 0 || v < 0 || v > 0xFF) {
+            esp_http_client_close(client);
+            esp_http_client_cleanup(client);
+            return ESP_ERR_INVALID_RESPONSE;
+        }
+        expected_hash[i] = (uint8_t)v;
+    }
+
+    mbedtls_sha256_context sha_ctx;
+    mbedtls_sha256_init(&sha_ctx);
+    mbedtls_sha256_starts(&sha_ctx, 0);
+
+    uint8_t *buf = NULL;
+    size_t cap = 0;
+    size_t total = 0;
+    uint8_t tmp_buf[512];
     err = ESP_OK;
-    while (read < content_length) {
-        int r = esp_http_client_read(client, (char *)buf + read, content_length - read);
+    while (1) {
+        int r = esp_http_client_read(client, (char *)tmp_buf, sizeof(tmp_buf));
         if (r < 0) {
             err = r;
             break;
         } else if (r == 0) {
-            err = ESP_ERR_HTTP_EAGAIN;
             break;
         }
-        read += r;
+        if (total + r > cap) {
+            size_t new_cap = cap + ((r > sizeof(tmp_buf)) ? r : sizeof(tmp_buf));
+            uint8_t *new_buf = heap_caps_realloc(buf, new_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+            if (!new_buf) {
+                err = ESP_ERR_NO_MEM;
+                break;
+            }
+            buf = new_buf;
+            cap = new_cap;
+        }
+        memcpy(buf + total, tmp_buf, r);
+        total += r;
+        mbedtls_sha256_update(&sha_ctx, tmp_buf, r);
     }
+
+    uint8_t actual_hash[32];
+    mbedtls_sha256_finish(&sha_ctx, actual_hash);
+    mbedtls_sha256_free(&sha_ctx);
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
-    if (err != ESP_OK || read != content_length) {
+
+    if (err != ESP_OK || (content_length >= 0 && total != content_length)) {
         free(buf);
         return (err != ESP_OK) ? err : ESP_ERR_HTTP_WRITE_DATA;
     }
+    if (memcmp(actual_hash, expected_hash, sizeof(expected_hash)) != 0) {
+        free(buf);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
     *data = buf;
-    *len = content_length;
-    ESP_LOGI(TAG, "Downloaded %d bytes from %s", content_length, url);
+    *len = total;
+    ESP_LOGI(TAG, "Downloaded %d bytes from %s", (int)total, url);
     return ESP_OK;
 }

--- a/components/image_fetcher/image_fetcher.h
+++ b/components/image_fetcher/image_fetcher.h
@@ -7,8 +7,9 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path);
 /**
  * @brief Download an image over HTTP into PSRAM.
  *
- * The function allocates a buffer in PSRAM sized according to the
- * server-provided Content-Length and fills it with the downloaded data.
+ * The function streams the response and grows the PSRAM buffer as needed
+ * until `esp_http_client_read()` returns 0. A SHA-256 checksum supplied by
+ * the server via the `X-File-SHA256` header is verified to ensure data integrity.
  *
  * @param url  HTTP URL of the image to download
  * @param data Output pointer receiving the allocated buffer

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -222,10 +222,4 @@ menu "Network options"
     config IMAGE_FETCH_URL
         string "Remote BMP URL"
         default "http://example.com/image.bmp"
-    config IMAGE_FETCH_INSECURE
-        bool "Allow insecure image fetch (skip TLS cert validation)"
-        default n
-        help
-            Enable this option to bypass TLS certificate validation when fetching images over HTTPS.
-            Use only for testing with self-signed certificates.
 endmenu


### PR DESCRIPTION
## Summary
- remove insecure image fetch option and always validate TLS while enabling HTTP keep-alive
- stream HTTP responses of unknown length and verify SHA-256 checksum from `X-File-SHA256` header
- document image integrity requirements and add mbedtls dependency

## Testing
- `idf.py build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ace196ccc483239b99c27133581725