### PR TITLE
Replace deprecated LCD panel include

### DIFF
--- a/components/gui/gui.h
+++ b/components/gui/gui.h
@@ -1,7 +1,7 @@
 #ifndef GUI_H
 #define GUI_H
 
-#include "esp_lcd_panel_interface.h"
+#include "esp_lcd_panel_ops.h"
 
 void gui_init(esp_lcd_panel_handle_t panel);
 


### PR DESCRIPTION
## Summary
- replace deprecated `esp_lcd_panel_interface.h` with `esp_lcd_panel_ops.h` in GUI component

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace87796f083239492a52d25b5607e