### PR TITLE
Handle Wi-Fi shutdown and server cleanup

### DIFF
--- a/components/wifi/wifi_manager.h
+++ b/components/wifi/wifi_manager.h
@@ -16,6 +16,7 @@ typedef void (*wifi_event_cb_t)(wifi_manager_event_t event);
 
 void wifi_manager_register_callback(wifi_event_cb_t cb);
 esp_err_t wifi_manager_start(void);
+void wifi_manager_stop(void);
 
 #ifdef __cplusplus
 }

--- a/main/main.c
+++ b/main/main.c
@@ -78,6 +78,8 @@ static void wifi_status_cb(wifi_manager_event_t event)
 static void app_cleanup(void)
 {
     touch_task_deinit();
+    wifi_manager_stop();
+    stop_file_server();
     esp_err_t unmount_ret = sd_mmc_unmount();
     if (unmount_ret != ESP_OK) {
         ESP_LOGW(TAG, "sd_mmc_unmount a échoué : %s", esp_err_to_name(unmount_ret));
@@ -213,8 +215,10 @@ void app_main(void)
     app_state_t state = APP_STATE_SOURCE_SELECTION;
 
     while (state != APP_STATE_EXIT) {
-        switch (state) {  
+        switch (state) {
         case APP_STATE_SOURCE_SELECTION:
+            wifi_manager_stop();
+            stop_file_server();
             img_src = draw_source_selection();
             lv_obj_clean(lv_scr_act());
             if (img_src == IMAGE_SOURCE_REMOTE) {


### PR DESCRIPTION
## Summary
- Track Wi-Fi event handler instances and implement wifi_manager_stop to stop Wi-Fi, unregister handlers, and free resources
- Expose wifi_manager_stop in header and use it along with stop_file_server during cleanup and when switching image sources

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ff4fabc83239b3b30e5d55a83d4