### PR TITLE
Add navigation queue deinitialization and cleanup hook

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -332,3 +332,11 @@ void draw_filename_bar(const char *path)
     }
 }
 
+void ui_navigation_deinit(void)
+{
+    if (s_nav_queue) {
+        vQueueDelete(s_nav_queue);
+        s_nav_queue = NULL;
+    }
+}
+

--- a/components/ui_navigation/ui_navigation.h
+++ b/components/ui_navigation/ui_navigation.h
@@ -41,5 +41,6 @@ void draw_filename_bar(const char *path);
 nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *prev_y);
 image_source_t draw_source_selection(void);
 void draw_orientation_menu(void);
+void ui_navigation_deinit(void);
 
 #endif // UI_NAVIGATION_H

--- a/main/main.c
+++ b/main/main.c
@@ -77,6 +77,7 @@ static void wifi_status_cb(wifi_manager_event_t event)
 
 static void app_cleanup(void)
 {
+    ui_navigation_deinit();
     touch_task_deinit();
     wifi_manager_stop();
     stop_file_server();
@@ -314,8 +315,10 @@ void app_main(void)
         case APP_STATE_NAVIGATION: {
             nav_action_t act = handle_touch_navigation(&index, &prev_x, &prev_y);
             if (act == NAV_EXIT) {
+                ui_navigation_deinit();
                 state = APP_STATE_EXIT;
             } else if (act == NAV_HOME) {
+                ui_navigation_deinit();
                 bmp_list_free();
                 index = 0;
                 prev_x = 0;


### PR DESCRIPTION
## Summary
- add `ui_navigation_deinit` to release navigation queue resources
- invoke navigation deinit during application cleanup and when leaving navigation state

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad753fed648323975fe009f9c11b93