### PR TITLE
Simplify touch navigation API

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -280,10 +280,8 @@ void draw_navigation_arrows(void)
     lv_label_set_text(lbl_rotate, "Rotation");
 }
 
-nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *prev_y)
+nav_action_t handle_touch_navigation(int8_t *idx)
 {
-    (void)prev_x;
-    (void)prev_y;
     int8_t dir;
     if (s_nav_queue && xQueueReceive(s_nav_queue, &dir, pdMS_TO_TICKS(50)) == pdTRUE) {
         if (dir == 2) {

--- a/components/ui_navigation/ui_navigation.h
+++ b/components/ui_navigation/ui_navigation.h
@@ -38,7 +38,7 @@ typedef enum {
 const char *draw_folder_selection(void);
 void draw_navigation_arrows(void);
 void draw_filename_bar(const char *path);
-nav_action_t handle_touch_navigation(int8_t *idx, uint16_t *prev_x, uint16_t *prev_y);
+nav_action_t handle_touch_navigation(int8_t *idx);
 image_source_t draw_source_selection(void);
 void draw_orientation_menu(void);
 void ui_navigation_deinit(void);

--- a/main/main.c
+++ b/main/main.c
@@ -210,8 +210,6 @@ void app_main(void)
     const char *selected_dir = NULL;
     image_source_t img_src = IMAGE_SOURCE_LOCAL;
     int8_t index = 0;
-    uint16_t prev_x = 0;
-    uint16_t prev_y = 0;
 
     app_state_t state = APP_STATE_SOURCE_SELECTION;
 
@@ -313,7 +311,7 @@ void app_main(void)
             break;  
 
         case APP_STATE_NAVIGATION: {
-            nav_action_t act = handle_touch_navigation(&index, &prev_x, &prev_y);
+            nav_action_t act = handle_touch_navigation(&index);
             if (act == NAV_EXIT) {
                 ui_navigation_deinit();
                 state = APP_STATE_EXIT;
@@ -321,8 +319,6 @@ void app_main(void)
                 ui_navigation_deinit();
                 bmp_list_free();
                 index = 0;
-                prev_x = 0;
-                prev_y = 0;
                 selected_dir = NULL;
                 lv_obj_clean(lv_scr_act());
                 state = APP_STATE_SOURCE_SELECTION;


### PR DESCRIPTION
## Summary
- drop obsolete `prev_x`/`prev_y` parameters from `handle_touch_navigation`
- update navigation handling to use simplified API and remove unused variables

## Testing
- ⚠️ `idf.py build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7cf5d97083239141f936658f330e