### PR TITLE
Add GT911 deinit routine and integrate cleanup

### DIFF
--- a/components/touch/gt911.c
+++ b/components/touch/gt911.c
@@ -21,6 +21,8 @@
 #include "gt911.h"
 
 static const char *TAG = "GT911";
+extern DEV_I2C_Port handle;                // I2C bus/device handle from i2c.c
+extern esp_lcd_touch_handle_t s_touch_handle; // Touch handle used by touch task
 
 /* GT911 registers */
 #define ESP_LCD_TOUCH_GT911_READ_KEY_REG    (0x8093)
@@ -415,6 +417,27 @@ esp_lcd_touch_handle_t touch_gt911_init()
     ESP_ERROR_CHECK(esp_lcd_touch_new_i2c_gt911(tp_io_handle, &tp_cfg, &tp_handle));
 
     return tp_handle;  // Return the touch controller handle
+}
+
+// Function to deinitialize the GT911 touch controller and I2C resources
+void touch_gt911_deinit(void)
+{
+    // Delete touch controller instance if initialized
+    if (tp_handle) {
+        esp_lcd_touch_gt911_del(tp_handle);
+        tp_handle = NULL;
+        s_touch_handle = NULL;
+    }
+
+    // Release I2C device and bus
+    if (handle.dev) {
+        i2c_master_bus_rm_device(handle.dev);
+        handle.dev = NULL;
+    }
+    if (handle.bus) {
+        i2c_del_master_bus(handle.bus);
+        handle.bus = NULL;
+    }
 }
 
 // Function to read touch points from the GT911 touch controller

--- a/components/touch/gt911.h
+++ b/components/touch/gt911.h
@@ -91,6 +91,11 @@ esp_lcd_touch_handle_t touch_gt911_init();
 touch_gt911_point_t touch_gt911_read_point(uint8_t max_touch_cnt);
 
 /**
+ * @brief Deinitialize the GT911 touch controller and release I2C resources
+ */
+void touch_gt911_deinit(void);
+
+/**
  * @brief Touch IO configuration structure for GT911
  *
  * This macro initializes the configuration structure for the GT911 touch controller's 

--- a/main/main.c
+++ b/main/main.c
@@ -79,6 +79,7 @@ static void app_cleanup(void)
 {
     ui_navigation_deinit();
     touch_task_deinit();
+    touch_gt911_deinit();
     wifi_manager_stop();
     stop_file_server();
     esp_err_t unmount_ret = sd_mmc_unmount();

--- a/main/touch_task.c
+++ b/main/touch_task.c
@@ -75,7 +75,6 @@ void touch_task_deinit(void)
     }
     if (s_touch_handle) {
         esp_lcd_touch_register_interrupt_callback(s_touch_handle, NULL);
-        esp_lcd_touch_del(s_touch_handle);
-        s_touch_handle = NULL;
+        // Deinitialization performed in touch_gt911_deinit()
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated `touch_gt911_deinit` to release touch driver and I2C bus
- expose deinit API in `gt911.h` and call it during application cleanup
- simplify touch task cleanup to rely on new deinit function

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad83a03d688323a72a5225c9c47e84