### PR TITLE
Use non-suffixed mbedtls SHA256 API with error handling

### DIFF
--- a/components/image_fetcher/image_fetcher.c
+++ b/components/image_fetcher/image_fetcher.c
@@ -81,8 +81,9 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
     mbedtls_sha256_context sha_ctx;
     mbedtls_sha256_init(&sha_ctx);
     FILE *f = NULL;
-    int rc = mbedtls_sha256_starts_ret(&sha_ctx, 0);
+    int rc = mbedtls_sha256_starts(&sha_ctx, 0);
     if (rc != 0) {
+        ESP_LOGE(TAG, "mbedtls_sha256_starts failed: %d", rc);
         if (f) {
             fclose(f);
         }
@@ -113,8 +114,9 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
         }
         fwrite(buf, 1, data_read, f);
         total_read += data_read;
-        rc = mbedtls_sha256_update_ret(&sha_ctx, buf, data_read);
+        rc = mbedtls_sha256_update(&sha_ctx, buf, data_read);
         if (rc != 0) {
+            ESP_LOGE(TAG, "mbedtls_sha256_update failed: %d", rc);
             fclose(f);
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
@@ -125,8 +127,9 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
     }
     fclose(f);
     uint8_t actual_hash[32];
-    rc = mbedtls_sha256_finish_ret(&sha_ctx, actual_hash);
+    rc = mbedtls_sha256_finish(&sha_ctx, actual_hash);
     if (rc != 0) {
+        ESP_LOGE(TAG, "mbedtls_sha256_finish failed: %d", rc);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         remove(dest_path);
@@ -205,8 +208,9 @@ esp_err_t image_fetch_http_to_psram(const char *url, uint8_t **data, size_t *len
 
     mbedtls_sha256_context sha_ctx;
     mbedtls_sha256_init(&sha_ctx);
-    int rc = mbedtls_sha256_starts_ret(&sha_ctx, 0);
+    int rc = mbedtls_sha256_starts(&sha_ctx, 0);
     if (rc != 0) {
+        ESP_LOGE(TAG, "mbedtls_sha256_starts failed: %d", rc);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         mbedtls_sha256_free(&sha_ctx);
@@ -238,8 +242,9 @@ esp_err_t image_fetch_http_to_psram(const char *url, uint8_t **data, size_t *len
         }
         memcpy(buf + total, tmp_buf, r);
         total += r;
-        rc = mbedtls_sha256_update_ret(&sha_ctx, tmp_buf, r);
+        rc = mbedtls_sha256_update(&sha_ctx, tmp_buf, r);
         if (rc != 0) {
+            ESP_LOGE(TAG, "mbedtls_sha256_update failed: %d", rc);
             free(buf);
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
@@ -249,8 +254,9 @@ esp_err_t image_fetch_http_to_psram(const char *url, uint8_t **data, size_t *len
     }
 
     uint8_t actual_hash[32];
-    rc = mbedtls_sha256_finish_ret(&sha_ctx, actual_hash);
+    rc = mbedtls_sha256_finish(&sha_ctx, actual_hash);
     if (rc != 0) {
+        ESP_LOGE(TAG, "mbedtls_sha256_finish failed: %d", rc);
         free(buf);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -75,9 +75,9 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     uint8_t hash[32];
     mbedtls_sha256_context ctx;
     mbedtls_sha256_init(&ctx);
-    int rc = mbedtls_sha256_starts_ret(&ctx, 0);
+    int rc = mbedtls_sha256_starts(&ctx, 0);
     if (rc != 0) {
-        ESP_LOGE(TAG, "mbedtls_sha256_starts_ret failed: %d", rc);
+        ESP_LOGE(TAG, "mbedtls_sha256_starts failed: %d", rc);
         mbedtls_sha256_free(&ctx);
         if (f) {
             fclose(f);
@@ -86,9 +86,9 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "hash fail");
         return ESP_FAIL;
     }
-    rc = mbedtls_sha256_update_ret(&ctx, (const unsigned char *)auth, strlen(auth));
+    rc = mbedtls_sha256_update(&ctx, (const unsigned char *)auth, strlen(auth));
     if (rc != 0) {
-        ESP_LOGE(TAG, "mbedtls_sha256_update_ret failed: %d", rc);
+        ESP_LOGE(TAG, "mbedtls_sha256_update failed: %d", rc);
         mbedtls_sha256_free(&ctx);
         if (f) {
             fclose(f);
@@ -97,10 +97,10 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "hash fail");
         return ESP_FAIL;
     }
-    rc = mbedtls_sha256_finish_ret(&ctx, hash);
+    rc = mbedtls_sha256_finish(&ctx, hash);
     mbedtls_sha256_free(&ctx);
     if (rc != 0) {
-        ESP_LOGE(TAG, "mbedtls_sha256_finish_ret failed: %d", rc);
+        ESP_LOGE(TAG, "mbedtls_sha256_finish failed: %d", rc);
         if (f) {
             fclose(f);
             unlink(filepath);


### PR DESCRIPTION
## Summary
- Replace deprecated `mbedtls_sha256_*_ret` with `mbedtls_sha256_*` in image fetcher and HTTP server
- Add detailed return code checks with logging and resource cleanup

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8845d8a083238229db2c58b98970