### PR TITLE
Clean up filename bar in ui_navigation_deinit

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -341,5 +341,11 @@ void ui_navigation_deinit(void)
         vQueueDelete(s_nav_queue);
         s_nav_queue = NULL;
     }
+
+    if (s_fname_bar) {
+        lv_obj_del(s_fname_bar);
+    }
+    s_fname_bar = NULL;
+    s_fname_label = NULL;
 }
 


### PR DESCRIPTION
## Summary
- Ensure `ui_navigation_deinit` deletes filename bar if present
- Reset filename bar and label pointers to NULL during cleanup

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8beb135c83239b4aa7e1b05e0e1a