### PR TITLE
Free SHA256 context on file-open failure

### DIFF
--- a/components/image_fetcher/image_fetcher.c
+++ b/components/image_fetcher/image_fetcher.c
@@ -98,6 +98,7 @@ esp_err_t image_fetch_http_to_sd(const char *url, const char *dest_path)
     if (!f) {
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
+        mbedtls_sha256_free(&sha_ctx);
         return ESP_FAIL;
     }
     uint8_t buf[512];


### PR DESCRIPTION
## Summary
- ensure SHA256 context is freed if destination file fails to open in image_fetcher

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad949e9624832392e3ec38e2b38c10