### PR TITLE
Handle navigation after displaying network upload URL

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -276,7 +276,7 @@ void app_main(void)
                                     lv_obj_clean(lv_scr_act());
                                     Paint_DrawString_EN(msg_x, msg_y, "Upload BMP via:", &Font24, BLACK, WHITE);
                                     Paint_DrawString_EN(msg_x, msg_y + TEXT_LINE_SPACING, url, &Font24, BLACK, WHITE);
-
+                                    state = APP_STATE_NAVIGATION;
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- After showing network upload URL, transition to navigation state to allow returning to menu or file reception.

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68adce8b1dfc832390d5c90350e96db4