### PR TITLE
Ensure source selection screen is freed

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -297,6 +297,8 @@ image_source_t draw_source_selection(void)
     while (s_src_choice == -1) {
         vTaskDelay(pdMS_TO_TICKS(10));
     }
+    lv_scr_load(NULL);           // unload selection screen to avoid it remaining active
+    lv_obj_del(scr);             // delete screen object to prevent RAM accumulation
     return (image_source_t)s_src_choice;
 }
 


### PR DESCRIPTION
## Summary
- Unload and delete temporary LVGL screen after choosing image source to prevent RAM buildup

## Testing
- `idf.py --version` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*
- `cmake ..` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68add12c6fc88323a8c83c3e78d7e33d