### PR TITLE
Free directory name after folder selection

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -212,7 +212,7 @@ void app_main(void)
 
             wifi_manager_register_callback(wifi_status_cb);
 
-            const char *selected_dir = NULL;
+            char *selected_dir = NULL;
             image_source_t img_src = IMAGE_SOURCE_LOCAL;
             int8_t index = 0;
 
@@ -308,6 +308,7 @@ void app_main(void)
                         break;
                     }
                     snprintf(g_base_path, sizeof(g_base_path), "%s/%s", MOUNT_POINT, selected_dir);
+                    char *selected_dir_tmp = selected_dir;
                     bmp_page_start = 0;
                     esp_err_t err = list_files_sorted(g_base_path, bmp_page_start, BMP_LIST_INIT_CAP);
                     if (err != ESP_OK) {
@@ -325,6 +326,8 @@ void app_main(void)
 
                         state = APP_STATE_NAVIGATION;
                     }
+                    free(selected_dir_tmp);
+                    selected_dir = NULL;
                     break;
 
                 case APP_STATE_NAVIGATION: {


### PR DESCRIPTION
## Summary
- prevent folder selection leaks by freeing selected directory string after building path
- adjust selected_dir type to allow memory release

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68addeb888d08323a1c08b2771518f12