### PR TITLE
refactor(can): add message presence status

### DIFF
--- a/components/can/can.c
+++ b/components/can/can.c
@@ -145,16 +145,24 @@ void can_write_Byte(twai_message_t message)
 /**
  * @brief Receives a CAN message.
  *
- * This function reads and logs received messages from the CAN interface.
+ * This function attempts to read a single message from the CAN interface
+ * without blocking. The received message is stored in the structure pointed to
+ * by the @p message parameter.
  *
- * @return The received CAN message.
+ * @param[out] message Pointer to structure that will hold the received message.
+ *
+ * @return true if a message was received, false if no message is available.
  */
-twai_message_t can_read_Byte()
+bool can_read_Byte(twai_message_t *message)
 {
-    twai_message_t message; // Variable to hold received message
-    while (twai_receive(&message, 0) == ESP_OK)
+    if (message == NULL)
     {
-        if (message.extd)
+        return false;
+    }
+
+    if (twai_receive(message, 0) == ESP_OK)
+    {
+        if (message->extd)
         {
             ESP_LOGI(CAN_TAG, "Message is in Extended Format");
         }
@@ -163,15 +171,17 @@ twai_message_t can_read_Byte()
             ESP_LOGI(CAN_TAG, "Message is in Standard Format");
         }
 
-        printf("ID: %lx\nByte:", message.identifier);
-        if (!message.rtr)
+        printf("ID: %lx\nByte:", message->identifier);
+        if (!message->rtr)
         {
-            for (int i = 0; i < message.data_length_code; i++)
+            for (int i = 0; i < message->data_length_code; i++)
             {
-                printf(" %d = %02x,", i, message.data[i]);
+                printf(" %d = %02x,", i, message->data[i]);
             }
             printf("\n");
         }
+        return true;
     }
-    return message;
+
+    return false;
 }

--- a/components/can/can.h
+++ b/components/can/can.h
@@ -18,7 +18,8 @@
 
 // Include necessary driver headers
 #include "driver/twai.h"   // TWAI (CAN) driver
-#include "io_extension.h"        // IO EXTENSION I2C CAN control header  
+#include "io_extension.h"        // IO EXTENSION I2C CAN control header
+#include <stdbool.h>              // For bool type used in API
 
 // Define the GPIO pins used for CAN communication
 #define TX_GPIO_NUM GPIO_NUM_20 // Transmit GPIO number for CAN
@@ -57,10 +58,15 @@ uint32_t can_read_alerts();
 void can_write_Byte(twai_message_t message);
 
 /**
- * @brief Reads a single byte of data from the CAN interface.
+ * @brief Reads a single CAN message from the interface.
  *
- * @return A CAN message containing the received data.
+ * This function attempts to receive one message without blocking and stores it
+ * in the provided output parameter.
+ *
+ * @param[out] message Pointer to structure where the received message will be stored.
+ *
+ * @return true if a message was received, false otherwise.
  */
-twai_message_t can_read_Byte();
+bool can_read_Byte(twai_message_t *message);
 
 #endif  // __CAN_H


### PR DESCRIPTION
## Summary
- add boolean return value to `can_read_Byte` to indicate message availability
- deliver received CAN frame via output parameter and include null check
- include `<stdbool.h>` and document new API

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec06c929483238dd931c46455efb9