### PR TITLE
Add deinit routines for CAN and RS485 display drivers

### DIFF
--- a/components/can_display/can_display.h
+++ b/components/can_display/can_display.h
@@ -17,6 +17,16 @@ extern "C" {
  */
 esp_err_t can_display_init(void);
 
+/**
+ * @brief Deinitialize TWAI interface and delete CAN task.
+ *
+ * Stops and uninstalls the TWAI driver and removes the task created by
+ * can_display_init().
+ *
+ * @return ESP_OK on success, an error code otherwise.
+ */
+esp_err_t can_display_deinit(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/rs485_display/rs485_display.h
+++ b/components/rs485_display/rs485_display.h
@@ -17,6 +17,16 @@ extern "C" {
  */
 esp_err_t rs485_display_init(void);
 
+/**
+ * @brief Deinitialize RS485 display UART and delete task.
+ *
+ * Removes the FreeRTOS task created by rs485_display_init() and deletes
+ * the UART driver.
+ *
+ * @return ESP_OK on success, an error code otherwise.
+ */
+esp_err_t rs485_display_deinit(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- retain FreeRTOS task handles for CAN and RS485 display helpers
- add can_display_deinit and rs485_display_deinit to stop drivers and delete tasks

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec4f61a04832398b31b3da957bc43