### PR TITLE
Use binary mode when storing HTTP uploads

### DIFF
--- a/main/http_server.c
+++ b/main/http_server.c
@@ -159,7 +159,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    f = fopen(filepath, "w");
+    f = fopen(filepath, "wb");
     if (!f) {
         ESP_LOGE(TAG, "fopen failed: %s", filepath);
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "open fail");


### PR DESCRIPTION
## Summary
- open uploaded files in binary mode to preserve data

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec5c3e1e48323aa551eb1f8d89cc8