### PR TITLE
Use images for navigation buttons with fallback

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <dirent.h>
 #include <limits.h>
+#include <stdio.h>
 #include "esp_log.h"
 
 extern UBYTE *BlackImage;
@@ -329,6 +330,21 @@ image_source_t draw_source_selection(void)
     return (image_source_t)s_src_choice;
 }
 
+static void add_btn_img_or_label(lv_obj_t *btn, const char *img_path, const char *fallback)
+{
+    FILE *f = fopen(img_path, "rb");
+    if (f) {
+        fclose(f);
+        lv_obj_t *img = lv_img_create(btn);
+        lv_img_set_src(img, img_path);
+        lv_obj_center(img);
+    } else {
+        lv_obj_t *lbl = lv_label_create(btn);
+        lv_label_set_text(lbl, fallback);
+        lv_obj_center(lbl);
+    }
+}
+
 void draw_navigation_arrows(void)
 {
     if (!s_nav_queue) {
@@ -345,31 +361,27 @@ void draw_navigation_arrows(void)
     lv_obj_set_size(btn_left, ARROW_WIDTH, ARROW_HEIGHT);
     lv_obj_set_pos(btn_left, g_display.margin_left, (g_display.height - ARROW_HEIGHT)/2);
     lv_obj_add_event_cb(btn_left, nav_btn_cb, LV_EVENT_CLICKED, (void*)(intptr_t)-1);
-    lv_obj_t *lbl_left = lv_label_create(btn_left);
-    lv_label_set_text(lbl_left, "<");
+    add_btn_img_or_label(btn_left, MOUNT_POINT "/pic/pic/arrow_left.bmp", "<");
 
     lv_obj_t *btn_right = lv_btn_create(scr);
     lv_obj_set_size(btn_right, ARROW_WIDTH, ARROW_HEIGHT);
     lv_obj_set_pos(btn_right, g_display.width - g_display.margin_right - ARROW_WIDTH,
                    (g_display.height - ARROW_HEIGHT)/2);
     lv_obj_add_event_cb(btn_right, nav_btn_cb, LV_EVENT_CLICKED, (void*)(intptr_t)1);
-    lv_obj_t *lbl_right = lv_label_create(btn_right);
-    lv_label_set_text(lbl_right, ">");
+    add_btn_img_or_label(btn_right, MOUNT_POINT "/pic/pic/arrow_right.bmp", ">");
 
     lv_obj_t *btn_rotate = lv_btn_create(scr);
     lv_obj_set_size(btn_rotate, 100, 40);
     lv_obj_set_pos(btn_rotate, (g_display.width - 100)/2, g_display.margin_top);
     lv_obj_add_event_cb(btn_rotate, nav_btn_cb, LV_EVENT_CLICKED, (void*)(intptr_t)2);
-    lv_obj_t *lbl_rotate = lv_label_create(btn_rotate);
-    lv_label_set_text(lbl_rotate, "Rotation");
+    add_btn_img_or_label(btn_rotate, MOUNT_POINT "/pic/pic/wifi.bmp", "Rotation");
 
     lv_obj_t *btn_home = lv_btn_create(scr);
     lv_obj_set_size(btn_home, 100, 40);
     lv_obj_set_pos(btn_home, g_display.margin_left,
                    g_display.height - g_display.margin_bottom - 40);
     lv_obj_add_event_cb(btn_home, nav_btn_cb, LV_EVENT_CLICKED, (void*)(intptr_t)3);
-    lv_obj_t *lbl_home = lv_label_create(btn_home);
-    lv_label_set_text(lbl_home, "Home");
+    add_btn_img_or_label(btn_home, MOUNT_POINT "/pic/pic/home.bmp", "Home");
 
     lv_obj_t *btn_exit = lv_btn_create(scr);
     lv_obj_set_size(btn_exit, 100, 40);
@@ -377,8 +389,7 @@ void draw_navigation_arrows(void)
                    g_display.width - g_display.margin_right - 100,
                    g_display.height - g_display.margin_bottom - 40);
     lv_obj_add_event_cb(btn_exit, nav_btn_cb, LV_EVENT_CLICKED, (void*)(intptr_t)4);
-    lv_obj_t *lbl_exit = lv_label_create(btn_exit);
-    lv_label_set_text(lbl_exit, "Exit");
+    add_btn_img_or_label(btn_exit, MOUNT_POINT "/pic/pic/bluetooth.bmp", "Exit");
 }
 
 nav_action_t handle_touch_navigation(int8_t *idx)


### PR DESCRIPTION
## Summary
- load navigation icons from SD card and replace text labels
- gracefully fall back to textual labels when icons are missing

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution)*
- `apt-get install -y espressif-idf` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed04494988323a0329dafa01b54d0