### PR TITLE
Fix const qualifier in folder selection

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -212,7 +212,7 @@ void app_main(void)
 
             wifi_manager_register_callback(wifi_status_cb);
 
-            char *selected_dir = NULL;
+            const char *selected_dir = NULL;
             image_source_t img_src = IMAGE_SOURCE_LOCAL;
             int8_t index = 0;
 
@@ -303,7 +303,6 @@ void app_main(void)
                         break;
                     }
                     snprintf(g_base_path, sizeof(g_base_path), "%s/%s", MOUNT_POINT, selected_dir);
-                    char *selected_dir_tmp = selected_dir;
                     bmp_page_start = 0;
                     esp_err_t err = list_files_sorted(g_base_path, bmp_page_start, BMP_LIST_INIT_CAP);
                     if (err != ESP_OK) {
@@ -321,7 +320,7 @@ void app_main(void)
 
                         state = APP_STATE_NAVIGATION;
                     }
-                    free(selected_dir_tmp);
+                    free((void *)selected_dir);
                     selected_dir = NULL;
                     break;
 


### PR DESCRIPTION
## Summary
- make selected_dir a const char pointer
- cast pointer when freeing to avoid const discarding warning

## Testing
- `idf.py build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aee9d1aab083239b7d0da07d962da5