### PR TITLE
Allow const driver data in touch configuration

### DIFF
--- a/components/touch/esp_lcd_touch.h
+++ b/components/touch/esp_lcd_touch.h
@@ -62,7 +62,7 @@ typedef struct {
     /*!< User data passed to callback */
     void *user_data;
     /*!< User data passed to driver */
-    void *driver_data;
+    const void *driver_data;
 } esp_lcd_touch_config_t;
 
 typedef struct {

--- a/components/touch/gt911.c
+++ b/components/touch/gt911.c
@@ -92,7 +92,7 @@ esp_err_t esp_lcd_touch_new_i2c_gt911(const esp_lcd_panel_io_handle_t io, const 
 
     /* Save config */
     memcpy(&esp_lcd_touch_gt911->config, config, sizeof(esp_lcd_touch_config_t));
-    esp_lcd_touch_io_gt911_config_t *gt911_config = (esp_lcd_touch_io_gt911_config_t *)esp_lcd_touch_gt911->config.driver_data;
+    const esp_lcd_touch_io_gt911_config_t *gt911_config = esp_lcd_touch_gt911->config.driver_data;
 
     /* Prepare pin for touch controller reset */
     if (esp_lcd_touch_gt911->config.rst_gpio_num != GPIO_NUM_NC) {


### PR DESCRIPTION
## Summary
- accept `const void *` in `esp_lcd_touch_config_t::driver_data`
- use const-qualified GT911 IO configuration when initializing the touch driver

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68aeedf1cb3c832389365bcbd57fffa3