### PR TITLE
Enforce PNG-only uploads and reject BMP files

### DIFF
--- a/main/http_server.c
+++ b/main/http_server.c
@@ -139,8 +139,14 @@ static esp_err_t upload_post_handler(httpd_req_t *req) {
   }
 
   size_t n = strlen(clean_name);
-  if (n < 4 || strcasecmp(&clean_name[n - 4], ".png") != 0) {
-    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Only .png allowed");
+  const char *ext = n >= 4 ? &clean_name[n - 4] : "";
+  if (strcasecmp(ext, ".png") != 0) {
+    if (strcasecmp(ext, ".bmp") == 0) {
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                          "BMP files are not supported. Please upload PNG");
+    } else {
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Only .png allowed");
+    }
     return ESP_FAIL;
   }
 


### PR DESCRIPTION
## Summary
- tighten upload extension validation to only allow `.png` files
- explicitly reject `.bmp` uploads with a clear error message

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find requested file `/tools/cmake/project.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68af02dcfbc883239aa75120219c5326