### PR TITLE
Refactor fs_seek signature for LVGL compatibility

### DIFF
--- a/components/lvgl_fs/lvfs_fatfs.c
+++ b/components/lvgl_fs/lvfs_fatfs.c
@@ -56,29 +56,25 @@ static lv_fs_res_t fs_close(lv_fs_drv_t * drv, void * file_p)
     return res == FR_OK ? LV_FS_RES_OK : LV_FS_RES_FS_ERR;
 }
 
-static lv_fs_res_t fs_seek(lv_fs_drv_t *drv, void *file_p, int32_t offset, lv_fs_whence_t whence)
+static lv_fs_res_t fs_seek(lv_fs_drv_t *drv, void *file_p, uint32_t offset, lv_fs_whence_t whence)
 {
     (void)drv;
 
     FIL *f = (FIL *)file_p;
-    int64_t target = 0;
+    uint64_t target = 0;
 
     switch(whence) {
         case LV_FS_SEEK_SET:
             target = offset;
             break;
         case LV_FS_SEEK_CUR:
-            target = (int64_t)f_tell(f) + offset;
+            target = (uint64_t)f_tell(f) + offset;
             break;
         case LV_FS_SEEK_END:
-            target = (int64_t)f_size(f) + offset;
+            target = (uint64_t)f_size(f) + offset;
             break;
         default:
             return LV_FS_RES_INV_PARAM;
-    }
-
-    if(target < 0) {
-        return LV_FS_RES_INV_PARAM;
     }
 
     FRESULT res = f_lseek(f, (FSIZE_t)target);


### PR DESCRIPTION
## Summary
- Update `fs_seek` callback to accept `uint32_t` offset and compute seek positions with `uint64_t`
- Drop negative-offset checks, relying on unsigned offset per LVGL API

## Testing
- ⚠️ `idf.py build` *(idf.py: command not found)*
- ⚠️ `pip install esp-idf` *(no matching distribution)*
- ⚠️ `cmake -S . -B build` *(missing /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68af18186ac0832388cc8c32268161f6