### PR TITLE
Use dynamic LVGL display width for buffer allocation

### DIFF
--- a/components/gui/gui.c
+++ b/components/gui/gui.c
@@ -57,12 +57,12 @@ void gui_init(esp_lcd_panel_handle_t panel)
     s_panel = panel;
     lv_init();
 
-    s_draw_buf = lv_draw_buf_create(LCD_H_RES, 10, LV_COLOR_FORMAT_NATIVE, LV_STRIDE_AUTO);
+    s_draw_buf = lv_draw_buf_create(g_display.width, 10, LV_COLOR_FORMAT_NATIVE, LV_STRIDE_AUTO);
     s_buf1 = s_draw_buf->data;
 
     s_disp = lv_display_create(g_display.width, g_display.height);
     lv_display_set_flush_cb(s_disp, lvgl_flush_cb);
-    lv_display_set_buffers(s_disp, s_buf1, NULL, LCD_H_RES * 10, LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_buffers(s_disp, s_buf1, NULL, g_display.width * 10 * sizeof(lv_color_t), LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     lv_indev_t *indev = lv_indev_create();
     lv_indev_set_read_cb(indev, lvgl_touch_read);


### PR DESCRIPTION
## Summary
- use `g_display.width` to size LVGL draw buffer and display buffers

## Testing
- `idf.py build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af1cba42e88323b503e3738b01e055