### PR TITLE
Use nav_cmd_t enumeration for navigation commands

### DIFF
--- a/components/ui_navigation/ui_navigation.c
+++ b/components/ui_navigation/ui_navigation.c
@@ -184,9 +184,9 @@ static void source_btn_cb(lv_event_t *e) {
 }
 
 static void nav_btn_cb(lv_event_t *e) {
-  int8_t dir = (int8_t)(intptr_t)lv_event_get_user_data(e);
+  nav_cmd_t cmd = (nav_cmd_t)(intptr_t)lv_event_get_user_data(e);
   if (s_nav_queue) {
-    xQueueSend(s_nav_queue, &dir, 0);
+    xQueueSend(s_nav_queue, &cmd, 0);
   }
 }
 
@@ -252,7 +252,7 @@ static void add_btn_img_or_label(lv_obj_t *btn, const char *img_path,
 
 void draw_navigation_arrows(void) {
   if (!s_nav_queue) {
-    s_nav_queue = xQueueCreate(5, sizeof(int8_t));
+    s_nav_queue = xQueueCreate(5, sizeof(nav_cmd_t));
     if (!s_nav_queue) {
       ESP_LOGE("NAV", "xQueueCreate failed");
       return;
@@ -266,7 +266,7 @@ void draw_navigation_arrows(void) {
   lv_obj_set_pos(btn_left, g_display.margin_left,
                  (g_display.height - ARROW_HEIGHT) / 2);
   lv_obj_add_event_cb(btn_left, nav_btn_cb, LV_EVENT_CLICKED,
-                      (void *)(intptr_t)-1);
+                      (void *)(intptr_t)NAV_CMD_PREV);
   add_btn_img_or_label(btn_left, MOUNT_POINT "/pic/arrow_left.png", "<");
 
   lv_obj_t *btn_right = lv_btn_create(scr);
@@ -275,14 +275,14 @@ void draw_navigation_arrows(void) {
                  g_display.width - g_display.margin_right - ARROW_WIDTH,
                  (g_display.height - ARROW_HEIGHT) / 2);
   lv_obj_add_event_cb(btn_right, nav_btn_cb, LV_EVENT_CLICKED,
-                      (void *)(intptr_t)1);
+                      (void *)(intptr_t)NAV_CMD_NEXT);
   add_btn_img_or_label(btn_right, MOUNT_POINT "/pic/arrow_right.png", ">");
 
   lv_obj_t *btn_rotate = lv_btn_create(scr);
   lv_obj_set_size(btn_rotate, 100, 40);
   lv_obj_set_pos(btn_rotate, (g_display.width - 100) / 2, g_display.margin_top);
   lv_obj_add_event_cb(btn_rotate, nav_btn_cb, LV_EVENT_CLICKED,
-                      (void *)(intptr_t)2);
+                      (void *)(intptr_t)NAV_CMD_ROTATE);
   add_btn_img_or_label(btn_rotate, MOUNT_POINT "/pic/wifi.png", "Rotation");
 
   lv_obj_t *btn_home = lv_btn_create(scr);
@@ -290,7 +290,7 @@ void draw_navigation_arrows(void) {
   lv_obj_set_pos(btn_home, g_display.margin_left,
                  g_display.height - g_display.margin_bottom - 40);
   lv_obj_add_event_cb(btn_home, nav_btn_cb, LV_EVENT_CLICKED,
-                      (void *)(intptr_t)3);
+                      (void *)(intptr_t)NAV_CMD_HOME);
   add_btn_img_or_label(btn_home, MOUNT_POINT "/pic/home.png", "Home");
 
   lv_obj_t *btn_exit = lv_btn_create(scr);
@@ -298,37 +298,39 @@ void draw_navigation_arrows(void) {
   lv_obj_set_pos(btn_exit, g_display.width - g_display.margin_right - 100,
                  g_display.height - g_display.margin_bottom - 40);
   lv_obj_add_event_cb(btn_exit, nav_btn_cb, LV_EVENT_CLICKED,
-                      (void *)(intptr_t)4);
+                      (void *)(intptr_t)NAV_CMD_EXIT);
   add_btn_img_or_label(btn_exit, MOUNT_POINT "/pic/bluetooth.png", "Exit");
 }
 
 nav_action_t handle_touch_navigation(int8_t *idx) {
-  int8_t dir;
+  nav_cmd_t cmd;
   if (s_nav_queue &&
-      xQueueReceive(s_nav_queue, &dir, pdMS_TO_TICKS(50)) == pdTRUE) {
-    if (dir == 2) {
+      xQueueReceive(s_nav_queue, &cmd, pdMS_TO_TICKS(50)) == pdTRUE) {
+    if (cmd == NAV_CMD_ROTATE) {
       if (png_list.size > 0) {
         draw_filename_bar(png_list.items[*idx]);
       }
       return NAV_ROTATE;
     }
-    if (dir == 3) {
+    if (cmd == NAV_CMD_HOME) {
       return NAV_HOME;
     }
-    if (dir == 4) {
+    if (cmd == NAV_CMD_EXIT) {
       return NAV_EXIT;
     }
-    if (png_list.size == 0) {
-      return NAV_NONE;
+    if (cmd == NAV_CMD_NEXT || cmd == NAV_CMD_PREV) {
+      if (png_list.size == 0) {
+        return NAV_NONE;
+      }
+      *idx += (int8_t)cmd;
+      if (*idx >= (int8_t)png_list.size) {
+        *idx = 0;
+      } else if (*idx < 0) {
+        *idx = (int8_t)png_list.size - 1;
+      }
+      draw_filename_bar(png_list.items[*idx]);
+      return NAV_SCROLL;
     }
-    *idx += dir;
-    if (*idx >= (int8_t)png_list.size) {
-      *idx = 0;
-    } else if (*idx < 0) {
-      *idx = (int8_t)png_list.size - 1;
-    }
-    draw_filename_bar(png_list.items[*idx]);
-    return NAV_SCROLL;
   }
   return NAV_NONE;
 }

--- a/components/ui_navigation/ui_navigation.h
+++ b/components/ui_navigation/ui_navigation.h
@@ -30,6 +30,15 @@ typedef enum {
 } nav_action_t;
 
 typedef enum {
+    NAV_CMD_PREV  = -1,
+    NAV_CMD_NONE  = 0,
+    NAV_CMD_NEXT  = 1,
+    NAV_CMD_ROTATE = 2,
+    NAV_CMD_HOME   = 3,
+    NAV_CMD_EXIT   = 4
+} nav_cmd_t;
+
+typedef enum {
     IMAGE_SOURCE_LOCAL = 0,
     IMAGE_SOURCE_REMOTE,
     IMAGE_SOURCE_NETWORK


### PR DESCRIPTION
## Summary
- define `nav_cmd_t` enumeration for navigation command values
- refactor button callbacks and touch handler to use `nav_cmd_t` instead of numeric codes

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1e7e27288323bd2d79941e8fb8a8